### PR TITLE
Stop losing work, and stop measuring it with a leaky ruler

### DIFF
--- a/rag.py
+++ b/rag.py
@@ -200,6 +200,67 @@ class Retriever:
         """Stable key for repeated/rephrased queries."""
         return " ".join(sorted(_normalize(query)))
 
+    # A term carried by more than this share of the corpus cannot be what
+    # makes one note the right answer. Measured on this project's notes:
+    # topical words sit at or below 11% ("wifi" 5%, "coffee" 11%, "bicycle"
+    # 5%) while the words that were actually deciding the ranking sit far
+    # above it ("skill" 53%, "the" 68%, "for" 47%). A third is the gap.
+    _MAX_DISCRIMINATIVE_SHARE = 1 / 3
+    # Corpus statistics alone cannot catch these. On a small, technical set of
+    # notes "how" and "do" are genuinely rare — most notes are written as
+    # numbered steps and simply never use them — so the share test called them
+    # discriminative and admitted the Device Awareness note for "how do I make
+    # coffee". A stopword is never the reason a note is the right answer, at
+    # any frequency, so it is excluded on principle rather than by counting.
+    _NEVER_DISCRIMINATIVE = frozenset("""
+        how do does did can could should would will shall may might must
+        what when where which who whom whose why is are was were be been being
+        have has had am the and or but if then than that this these those
+        for to of in on at by with from as into about over under
+        my me you your yours it its they them their we us our
+        one two some any all no not so just now new get got make made made
+        need want like use used using please tell show give take put
+        thing things stuff way ways time times step steps skill skills
+        """.split())
+
+    @classmethod
+    def _is_discriminative(cls, term: str, appears: int, total: int) -> bool:
+        if term in cls._NEVER_DISCRIMINATIVE:
+            return False
+        return 0 < appears <= total * cls._MAX_DISCRIMINATIVE_SHARE
+    # Below this many notes the share of a term is too noisy to act on — with
+    # four notes, one is 25% and two is 50%, so the cutoff would be deciding
+    # on nothing. Small corpora keep the old behaviour.
+    _MIN_NOTES_FOR_FLOOR = 5
+
+    @classmethod
+    def _discriminative_terms(cls, query_terms: list[str],
+                              normalized_docs) -> set[str] | None:
+        """Query terms rare enough to justify returning a note at all.
+
+        IDF ranks well and cannot say "none of these". When a query's topical
+        words appear in no note — asking about bread with no bread note — the
+        whole ranking falls to whatever common words are left, and the top
+        three come back as confidently as a real match. Measured: "save a
+        skill for making bread" returned Device Awareness, Coffee Making and
+        Quick Task Helper, decided by "skill", "for" and "save".
+
+        That is not a relevance problem. A retrieved note is pasted into the
+        model's context, skill notes are procedures, and the model performs
+        them: a bicycle question pulled the Browser Driver note and produced
+        real clicks on google.com. An empty result is strictly better than a
+        confident wrong one.
+
+        Returns None when the corpus is too small to judge.
+        """
+        docs = [set(d) for d in normalized_docs]
+        total = len(docs)
+        if total < cls._MIN_NOTES_FOR_FLOOR:
+            return None
+        return {t for t in set(query_terms)
+                if cls._is_discriminative(
+                    t, sum(1 for d in docs if t in d), total)}
+
     @staticmethod
     def _idf(query_terms: list[str], documents) -> dict[str, float]:
         """How much each query term distinguishes one document from another.
@@ -268,9 +329,18 @@ class Retriever:
                 pass
 
         notes = self._load_notes()
+        normalized = {name: _normalize(text) for name, text in notes.items()}
         idf = self._idf(query_terms, notes.values())
+        # Nothing rare enough to justify an answer means the honest answer is
+        # no notes, not the three least-bad ones.
+        discriminative = self._discriminative_terms(query_terms, normalized.values())
+        if discriminative is not None and not discriminative:
+            return []
         scored = []
         for name, text in notes.items():
+            if discriminative is not None and not (
+                    discriminative & set(normalized[name])):
+                continue
             s = self._score(query_terms, text, idf)
             if s > 0:
                 scored.append({

--- a/symbio/app/chat.py
+++ b/symbio/app/chat.py
@@ -29,7 +29,7 @@ from symbio.config import _adapter_matches_model
 from symbio.computer import BrowserSession
 from symbio import safety
 from symbio.tools import tool_few_shots
-from symbio.app import cron, dispatch, golden, health, learn, local_telemetry, memory, mcp_bridge, prompts, prune, sandbox, sessions, setup, skills, tooling, training, web
+from symbio.app import cron, dispatch, golden, health, learn, local_telemetry, memory, mcp_bridge, pending, prompts, prune, sandbox, sessions, setup, skills, tooling, training, web
 from symbio.app.config import apply_gpu_limits, config_show, set_config_value
 from tag_rag import TagIndex
 
@@ -502,7 +502,15 @@ class _Spinner:
             self.label = label
 
     def start(self):
-        if not self.active or self._thread is not None:
+        if self._thread is not None:
+            return
+        if not self.active:
+            # No animation without a TTY, but silence is not the alternative:
+            # a turn that prints nothing between the prompt and the reply looks
+            # like a hang, and the wait here is tens of seconds on an 8B. One
+            # static line costs nothing and cannot be mistaken for frozen.
+            sys.stdout.write(f"  {self.label}\n")
+            sys.stdout.flush()
             return
         self._stop_event.clear()
         self._start_time = time.perf_counter()
@@ -621,7 +629,7 @@ def print_banner(config: dict[str, Any], adapter_loaded: bool, dataset_size: int
     output_fn(f"   Data   : {dataset_size:,} bytes")
     output_fn(f"   Notes  : {note_count}")
     output_fn("-" * 50)
-    output_fn("Commands: /quit  /save  /train  /retrain  /train_worker  /golden  /learn  /forget_last  /status  /prune  /selfcheck  /setup  /compact  /help")
+    output_fn("Commands: /quit  /save  /train  /retrain  /train_worker  /resume  /golden  /learn  /forget_last  /status  /prune  /selfcheck  /setup  /compact  /help")
     output_fn("         /run <cmd>  /note [title]  /notes  /index-notes [--force]  /auto-index on|off  /new-skill <name>  /skills  /skill-adapters  /digest  /cron  /config  /archive  /restore")
     output_fn("         /build-mcp <name> | <description>  /mcp-tools  /hosts  /telemetry on|off  /feedback <text>")
     output_fn("  (Caine can also use <note>, <cmd>, <py>, <digest />, <train />, <cron> by itself)")
@@ -828,6 +836,10 @@ class ChatSession:
         # happen when the model is loaded lazily or never.
         if self.config.get("prune", {}).get("on_boot", True):
             self._self_prune()
+        # Pick up whatever the last process was in the middle of. Cheap, and
+        # runs before the model loads: this is reading a small JSON file and,
+        # at most, copying an adapter directory back over a truncated one.
+        self._recover_pending()
         self.user_turns = 0
         self.auto_searches = 0
         # Resolved subject for a subjectless "check online"-style command this
@@ -1091,6 +1103,70 @@ class ChatSession:
             self.retriever.invalidate_cache()
         return report
 
+    def _recover_pending(self):
+        """Report work the last process did not finish, and repair its damage.
+
+        The repair is automatic because there is only one right answer to it:
+        a run killed partway through leaves an adapter directory the trainer
+        was still writing, next to a complete copy of the last good one, and
+        loading the truncated version as if it were trained is worse than any
+        cost of putting the backup back.
+
+        Re-running the training is not automatic. It is minutes of GPU and a
+        second full copy of the weights, and starting one unprompted at boot
+        is close to a description of how the machine went down. The list is
+        printed; /resume runs it.
+        """
+        try:
+            repairs = pending.recover(restore_fn=training.restore_adapter)
+            outstanding = pending.describe_outstanding()
+        except Exception as e:
+            self.logger.warning(f"Pending-task recovery failed: {e}")
+            return
+        for line in repairs:
+            self.output_fn(f"  [Resume] {line}")
+        if outstanding:
+            self.output_fn(
+                f"  [Resume] {len(outstanding)} unfinished task(s) carried "
+                f"over. Run /resume to pick them up, /resume clear to drop them.")
+            for line in outstanding:
+                self.output_fn(f"    - {line}")
+
+    def _cmd_resume(self, arg: str = ""):
+        """List, run, or drop the work carried over from a previous session."""
+        arg = (arg or "").strip().lower()
+        outstanding = pending.outstanding()
+        if arg == "clear":
+            dropped = pending.clear()
+            self.output_fn(f"  [Resume] Dropped {dropped} carried-over task(s).")
+            return
+        if not outstanding:
+            self.output_fn("  [Resume] Nothing carried over — every task finished.")
+            return
+        if arg != "run":
+            self.output_fn(f"  [Resume] {len(outstanding)} task(s) waiting:")
+            for line in pending.describe_outstanding():
+                self.output_fn(f"    - {line}")
+            self.output_fn("  [Resume] /resume run to start them, "
+                           "/resume clear to drop them.")
+            return
+
+        # Strictly one at a time, and the headmaster's own run last: each is a
+        # trainer holding a full copy of the weights, and overlapping two of
+        # them is the failure that made any of this necessary.
+        for task in sorted(outstanding, key=lambda t: t.get("kind") == "train_headmaster"):
+            kind, role = task.get("kind"), task.get("role")
+            self.output_fn(f"  [Resume] {task.get('detail', kind)}...")
+            if kind == "train_worker" and role:
+                trained, msg = dispatch.guarded_train_worker(role, self.config)
+                self.output_fn(f"  [Resume] {msg}")
+            elif kind == "train_headmaster":
+                self._guarded_train()
+            else:
+                self.output_fn(
+                    f"  [Resume] Nothing knows how to re-run '{kind}'; "
+                    f"leaving it on the list.")
+
     def _run_post_load_self_check(self):
         """AI-driven feature verification after the model has finished loading.
 
@@ -1249,6 +1325,17 @@ class ChatSession:
             return False
         if any(meta.get(k) != v for k, v in want.items()):
             # The model, adapter or prompt changed since it was written.
+            path.unlink(missing_ok=True)
+            return False
+        # Loading a cache is not the same as being able to use one. A file
+        # written by an earlier process can carry arrays bound to an MLX stream
+        # that does not exist here, and nothing notices until generation, which
+        # then dies mid-turn. Touching the state now moves that failure to the
+        # one place equipped to handle it: prefill just runs normally instead.
+        try:
+            mx.eval([c.state for c in cache])
+        except Exception as e:
+            self._log_info(f"Prompt cache unusable in this process, discarding: {e}")
             path.unlink(missing_ok=True)
             return False
         self._prompt_cache = cache
@@ -1754,6 +1841,14 @@ class ChatSession:
             )
         self.output_fn("  [Train] Backing up current adapter before training...")
         backup_dir = training.backup_adapter() if golden_on else None
+        # Between here and discard_adapter_backup the previous adapter exists
+        # only inside backup_dir, and the adapter directory itself is whatever
+        # the trainer has written so far. A crash in that window used to leave
+        # both facts on the floor: an orphaned .bak nobody knew was live, and a
+        # half-written adapter that loaded as the real one.
+        task_id = pending.open_task(
+            "train_headmaster", "training for the headmaster adapter",
+            backup_dir=str(backup_dir) if backup_dir else None)
 
         try:
             trained = self._train_unloaded(iters=iters)
@@ -1874,6 +1969,7 @@ class ChatSession:
             self.output_fn(f"  [Train] {adapter_status_value(self.config, self.adapter_loaded)}")
             return True
         finally:
+            pending.finish(task_id)
             training.discard_adapter_backup(backup_dir)
 
     def _run_wildcard_check(self, learn_cfg: dict[str, Any]):
@@ -1983,6 +2079,13 @@ class ChatSession:
         elif cmd == "/retrain":
             self._cmd_retrain()
 
+        elif cmd.startswith("/resume"):
+            # `cmd` is the whole line, not the first word, so an equality test
+            # here silently drops every argument form — /resume listed fine
+            # and /resume run fell through to "Unknown command".
+            parts = user_input.split(None, 1)
+            self._cmd_resume(parts[1] if len(parts) == 2 else "")
+
         elif cmd.startswith("/train_worker"):
             parts = user_input.split(None, 1)
             role = parts[1].strip() if len(parts) == 2 else ""
@@ -2065,12 +2168,17 @@ class ChatSession:
             self._learn_from_correction(verbose=True)
 
         elif cmd == "/skills":
-            skills = memory.list_skills()
-            if not skills:
+            # Not `skills`: binding that name anywhere in this function makes
+            # it local for the whole of it, so the module import at the top
+            # stops resolving and /skill-adapters — hundreds of lines below,
+            # in the same function — dies with UnboundLocalError before it
+            # runs a line of its own.
+            saved_skills = memory.list_skills()
+            if not saved_skills:
                 self.output_fn("  No skills saved yet.")
             else:
-                self.output_fn(f"  {len(skills)} skill(s):")
-                for title, path in skills:
+                self.output_fn(f"  {len(saved_skills)} skill(s):")
+                for title, path in saved_skills:
                     self.output_fn(f"    - {title}  ({path.name})")
 
         elif cmd.startswith("/new-skill"):
@@ -2303,6 +2411,11 @@ class ChatSession:
                 idle_days = (datetime.now() - last_used).days
                 self.output_fn(f"  Adapter last used: {idle_days} day(s) ago")
             self.output_fn(f"  Learn: {learn_progress_line(self.config)}")
+            carried_over = pending.describe_outstanding()
+            if carried_over:
+                self.output_fn(f"  Unfinished tasks: {len(carried_over)} (/resume)")
+                for line in carried_over:
+                    self.output_fn(f"    - {line}")
             dispatch_on = self.config.get("dispatch", {}).get("enabled", False)
             loaded_workers = self.dispatch.loaded_roles()
             self.output_fn(
@@ -2948,6 +3061,10 @@ class ChatSession:
         # tool tag, we nudge it to retry — otherwise Caine just explains the
         # failure and gives up after one attempt.
         pending_browser_error: str | None = None
+        # Set the moment the user declines anything, and never cleared before
+        # the turn ends: a "no" applies to the rest of the turn, not just to
+        # the one tool that asked.
+        user_refused_this_turn = False
         browser_retry_nudged = False
         blank_retry_nudged = False
         echo_retry_nudged = False
@@ -3353,7 +3470,23 @@ class ChatSession:
             self.output_fn(f"  [Tool: {name}]")
             if name in _WEB_TOOLS:
                 web_used = True
-            observation = self._execute_tool(name, params)
+            if user_refused_this_turn:
+                # Observed live: browser_open was denied at the domain prompt,
+                # and the very next round the model ran `open -a 'Google
+                # Chrome'` through run_command and reported success. The
+                # sandbox is a denylist, so `open` was never going to stop it
+                # — but no denylist should have to. A refusal is about the
+                # action the user was asked about, not the tool that happened
+                # to ask, so once one is given nothing else runs this turn.
+                observation = (
+                    "Blocked: the user declined this action earlier in this "
+                    "turn. Do not attempt it by other means. Tell them it was "
+                    "not done.")
+                self.output_fn(f"  [Safety] {observation}")
+            else:
+                observation = self._execute_tool(name, params)
+                if learn.is_user_refusal(observation):
+                    user_refused_this_turn = True
             local_telemetry.log_event(
                 "tool", name=name, ok=not learn.sounds_like_tool_error(observation),
                 result=observation,
@@ -3403,13 +3536,23 @@ class ChatSession:
             # filter and the turn ends on a bare "Clicking the button." with
             # nothing clicked. Retries stay capped so a call that keeps
             # failing still can't spin.
-            if learn.sounds_like_tool_error(observation):
+            # A refusal is the exception: no retry turns a "no" into a "yes",
+            # and re-running the call just puts the same confirmation prompt
+            # in front of the user again. Observed live — one denied
+            # browser_open asked twice in a single turn.
+            if (learn.sounds_like_tool_error(observation)
+                    and not learn.is_user_refusal(observation)):
                 failed_calls[tool_key] = failed_calls.get(tool_key, 0) + 1
                 if failed_calls[tool_key] < _MAX_TOOL_RETRIES:
                     executed_calls.discard(tool_key)
             # Track browser-action failures so we can force a retry if the
             # model tries to end the turn without another tool tag.
-            if name in _BROWSER_ACTION_TOOLS and learn.sounds_like_tool_error(observation):
+            # A refusal is excluded here for the same reason: this nudge tells
+            # the model "do not end the turn until the request is completed",
+            # which against a denied request is an instruction to keep asking.
+            if (name in _BROWSER_ACTION_TOOLS
+                    and learn.sounds_like_tool_error(observation)
+                    and not learn.is_user_refusal(observation)):
                 pending_browser_error = observation
             else:
                 pending_browser_error = None
@@ -3426,6 +3569,16 @@ class ChatSession:
                     "\n\n[Answer ONLY from the results above. If they do not state "
                     "the answer, say plainly that you could not find it — do not "
                     "repeat your earlier claim or guess.]"
+                )
+            if learn.is_user_refusal(observation):
+                # Without this the turn ends on the sentence the model wrote
+                # *before* the tool ran — "Opening apple.com for you." — which
+                # reports an action the user had just blocked. Seen live: the
+                # denial changed nothing about the final answer.
+                observation += (
+                    "\n\n[The user declined this. It did NOT happen. Say plainly "
+                    "that you did not do it because they declined, and do not "
+                    "describe it as done or in progress. Do not try another way.]"
                 )
             # Present results in Hermes-style <tool_response> JSON so the model
             # learns the structured format, while keeping a plain-text fallback

--- a/symbio/app/cli.py
+++ b/symbio/app/cli.py
@@ -732,6 +732,18 @@ def _cmd_train(config: dict[str, Any], skill: str | None = None,
             return 1
         model_name = entry.get("model_name")
         print(f"  [Train] Training worker '{role}' ({model_name}).")
+        # Through the guarded path, not run_training directly. Calling the
+        # trainer straight left a worker trained here with none of the
+        # protection the same run gets from /train_worker or a resumed task:
+        # no golden baseline, no rollback on regression, and no update to the
+        # journal — so a skill trained this way stayed listed as owed forever
+        # while its adapter sat finished on disk.
+        from symbio.app.dispatch import guarded_train_worker
+
+        trained, message = guarded_train_worker(
+            role, config, iters=iters, resume=resume)
+        print(f"  [Worker] {message}")
+        return 0 if trained else 1
 
     return 0 if run_training(config, role=role, model_name=model_name,
                              resume=resume, iters=iters) else 1

--- a/symbio/app/config.py
+++ b/symbio/app/config.py
@@ -280,6 +280,10 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # so without this every skill dispatch holds two full copies of those
         # weights. Costs a reload per delegation; that is the price of a skill
         # worker at headmaster size on a machine that cannot hold both.
+        # The worker is unloaded again before the headmaster comes back, so
+        # this really does mean one model resident at a time — reloading the
+        # headmaster on top of a still-resident worker was the same double
+        # residency one turn later, and it OOM'd the machine.
         "headmaster_deep_sleep_while_workers": False,
         "hot_swap_adapters": True,
         # When a headmaster-sized worker cannot be hot-swapped, the fallback is

--- a/symbio/app/dispatch.py
+++ b/symbio/app/dispatch.py
@@ -23,7 +23,7 @@ from mlx_lm import generate, load
 from mlx_lm.sample_utils import make_sampler
 
 from symbio import constants
-from symbio.app import golden, tooling, training
+from symbio.app import golden, pending, tooling, training
 
 
 def load_catalog() -> dict[str, dict[str, Any]]:
@@ -251,19 +251,43 @@ class WorkerPool:
     def _dispatch_cfg(self) -> dict[str, Any]:
         return self.config.get("dispatch", {})
 
+    def _evict(self, roles: list[str]):
+        """Drop `roles` and hand their memory back to the system now.
+
+        Dropping the dict entry is not the same as freeing the weights. MLX
+        holds them in unified memory charged to the process until the
+        allocator reclaims it, so an eviction that is only a `del` leaves the
+        old worker fully resident right up to the moment the *next* one is
+        loaded — which is exactly when the machine can least afford it. This
+        is the same reason _reload_model frees before it loads.
+        """
+        if not roles:
+            return
+        for role in roles:
+            self._resident.pop(role, None)
+        training.release_model()
+
     def _evict_idle(self):
         idle_minutes = float(self._dispatch_cfg().get("worker_idle_unload_minutes", 10))
         if idle_minutes <= 0:
             return
         cutoff = time.time() - idle_minutes * 60
-        for role in [r for r, (_, _, ts) in self._resident.items() if ts < cutoff]:
-            del self._resident[role]
+        self._evict([r for r, (_, _, ts) in self._resident.items() if ts < cutoff])
 
     def _evict_lru_if_needed(self):
         max_resident = max(1, int(self._dispatch_cfg().get("max_resident_workers", 1)))
         while len(self._resident) >= max_resident:
             oldest_role = min(self._resident, key=lambda r: self._resident[r][2])
-            del self._resident[oldest_role]
+            self._evict([oldest_role])
+
+    def unload_all(self, reason: str = "") -> list[str]:
+        """Evict every resident worker. Returns the roles that were dropped."""
+        roles = list(self._resident)
+        self._evict(roles)
+        if roles and reason:
+            self._status(f"  [Dispatch] Unloading worker(s) "
+                         f"{', '.join(roles)}: {reason}")
+        return roles
 
     def loaded_roles(self) -> list[str]:
         return list(self._resident)
@@ -466,6 +490,15 @@ class WorkerPool:
             return label_worker_reply(role, reply)
         finally:
             if deep_sleep and self.after_worker_fn is not None:
+                # The worker is still resident at this point, so waking the
+                # headmaster on top of it puts both models in RAM at once —
+                # the exact state deep sleep exists to prevent, just moved
+                # from before the worker ran to after it finished. Deep sleep
+                # is the operator saying this machine holds one model at a
+                # time, so the worker goes before the headmaster comes back.
+                # It costs the worker's warm weights on the next delegation;
+                # the alternative cost is the machine.
+                self.unload_all("headmaster is waking up")
                 self._status("  [Dispatch] Waking headmaster back up...")
                 self.after_worker_fn()
 
@@ -534,14 +567,22 @@ class WorkerPool:
         )
 
 
-def guarded_train_worker(role: str, config: dict[str, Any], iters: int | None = None) -> tuple[bool, str]:
+def guarded_train_worker(role: str, config: dict[str, Any], iters: int | None = None,
+                         resume: bool = False) -> tuple[bool, str]:
     """Train a worker's own adapter and golden-check it the same way
     ChatSession._guarded_train protects the headmaster's: baseline golden
     run, backup, train, reload, recheck, auto-rollback on regression.
     Returns (trained, status_message)."""
     entry = catalog_entry_for_role(role)
     if entry is None:
-        return False, f"No worker configured for role '{role}'."
+        # Nothing can ever run this, so a record asking for it is not owed
+        # work — it is a line that reappears at every start and that /resume
+        # run can never clear, because this return happens before the task is
+        # even opened. Deleting a skill leaves exactly that behind.
+        dropped = pending.clear(kind="train_worker", role=role)
+        return False, (
+            f"No worker configured for role '{role}'."
+            + (f" Dropped {dropped} carried-over task(s) for it." if dropped else ""))
 
     # Refuse a run whose data was rendered by a different model's chat
     # template. Without this the run completes normally and produces an
@@ -601,6 +642,13 @@ def guarded_train_worker(role: str, config: dict[str, Any], iters: int | None = 
     baseline = None
     backup_dir = None
     adapter_dir = constants.adapter_dir_for(role)
+    # Recorded before anything expensive starts. Auto-train runs this whole
+    # function on a daemon thread, so an out-of-memory kill takes it with no
+    # unwind: without a note on disk the next start has no way to know the
+    # skill was seeded and never trained, or that the backup below is the only
+    # intact copy of the adapter.
+    task_id = pending.open_task(
+        "train_worker", f"training for worker '{role}'", role=role)
     # A baseline is only meaningful against weights this model can actually
     # load. An adapter from a different base is discarded silently, so the
     # "before" score would be the base model wearing the adapter's name — and
@@ -608,9 +656,30 @@ def guarded_train_worker(role: str, config: dict[str, Any], iters: int | None = 
     if (adapter_dir.exists()
             and (adapter_dir / "adapter_config.json").exists()
             and adapter_matches_model(adapter_dir, entry["model_name"])):
+        # This load is in-process and was unguarded: run_training's preflight
+        # covers the trainer child, but the baseline copy loaded here lands
+        # first and on top of whatever the session already holds. Auto-train
+        # runs on a background thread while the headmaster is still resident,
+        # so this is the load that goes over the edge.
+        shortfall = training.load_memory_shortfall(
+            config, entry["model_name"],
+            purpose=f"golden-check worker '{role}' before training")
+        if shortfall:
+            # Refused, not forgotten: the run is owed and stays on the books
+            # until it is resumed or dropped on purpose.
+            pending.update(task_id, state=pending.DEFERRED, pid=None,
+                           reason="not enough free memory to run safely")
+            return False, (
+                f"{shortfall} Free memory first (unload the headmaster, or "
+                f"wait for the workers to idle out) and retrain '{role}' — "
+                f"it is on the deferred list until then.")
         base_model, base_tok = load(entry["model_name"], adapter_path=str(adapter_dir))
         baseline = _run_golden(base_model, base_tok)
         backup_dir = training.backup_adapter(role=role)
+        # From here until discard_adapter_backup, the previous adapter exists
+        # only in that directory. If this process dies in between, recovery
+        # needs to be told where to find it.
+        pending.update(task_id, backup_dir=str(backup_dir) if backup_dir else None)
         # The baseline scores are all we need from these weights, and the
         # trainer below loads its own full copy. Holding this one until the
         # function returns would mean two copies resident across the whole
@@ -619,15 +688,44 @@ def guarded_train_worker(role: str, config: dict[str, Any], iters: int | None = 
         base_model, base_tok = None, None
         training.release_model()
 
+    # Whether the run got far enough that nothing is still owed. Only a run
+    # that produced an adapter counts: a refusal reported into a log nobody is
+    # reading — which is every auto-train, since it runs on a background
+    # thread — leaves a skill seeded and permanently untrained, and clearing
+    # its record is what makes that state invisible.
+    settled = False
     try:
         trained = training.run_training(
-            config, iters=iters, role=role, model_name=entry["model_name"])
+            config, iters=iters, role=role, model_name=entry["model_name"],
+            resume=resume)
         if not trained:
             return False, (
                 f"Training for '{role}' produced no usable adapter. Check the "
                 f"log above: either there was no new data, or the run ended "
                 f"before any checkpoint was written."
             )
+        settled = True
+
+        # The trainer child has exited by now, but its memory only comes back
+        # once the allocator reclaims it, and this is the load that would
+        # otherwise race it.
+        training.release_model()
+        shortfall = training.load_memory_shortfall(
+            config, entry["model_name"],
+            purpose=f"reload worker '{role}' to check the new adapter")
+        if shortfall:
+            # The adapter is already on disk and cannot be verified. Reverting
+            # to a backup loses one training run; shipping an unchecked
+            # adapter is what the golden set exists to prevent.
+            if backup_dir:
+                training.restore_adapter(backup_dir, role=role)
+                return False, (
+                    f"{shortfall} Worker '{role}' trained but could not be "
+                    f"golden-checked, so it was rolled back to the previous "
+                    f"adapter. Retrain when there is more memory free.")
+            return True, (
+                f"{shortfall} Worker '{role}' trained and kept unverified "
+                f"(no previous adapter to roll back to).")
 
         new_model, new_tok = load(entry["model_name"], adapter_path=str(adapter_dir))
         training.mark_adapter_used(role=role)
@@ -695,7 +793,16 @@ def guarded_train_worker(role: str, config: dict[str, Any], iters: int | None = 
                     training.release_model()
                     trained2 = training.run_training(
                         config, iters=extra_iters, role=role, model_name=entry["model_name"])
-                    if trained2:
+                    training.release_model()
+                    remedy_shortfall = training.load_memory_shortfall(
+                        config, entry["model_name"],
+                        purpose=f"reload worker '{role}' after remedy training")
+                    if trained2 and remedy_shortfall:
+                        # Leave `after` and `regressions` as the pre-remedy
+                        # result: unchecked is treated as failed, so the
+                        # rollback below still fires.
+                        print(f"  [Train] {remedy_shortfall}")
+                    elif trained2:
                         new_model, new_tok = load(
                             entry["model_name"], adapter_path=str(adapter_dir))
                         print(
@@ -718,4 +825,22 @@ def guarded_train_worker(role: str, config: dict[str, Any], iters: int | None = 
                 f"check(s) ({', '.join(regressions)}); kept anyway.")
         return True, f"Worker '{role}' trained ({after.pass_count}/{after.total} checks passing)."
     finally:
+        # An adapter was produced, so the work is done however the checks then
+        # graded it — a rollback is a decision about the result, not an
+        # unfinished run. Anything else stays owed and visible at the next
+        # start, which is the only place a background failure gets seen.
+        if settled:
+            pending.finish(task_id)
+        else:
+            pending.update(
+                task_id, state=pending.DEFERRED, pid=None,
+                reason="training did not produce an adapter (see the log; "
+                       "most often not enough free memory at the time)")
         training.discard_adapter_backup(backup_dir)
+        # Whatever this run loaded goes back to the system now rather than
+        # whenever the collector next runs. Callers include a background
+        # thread finishing beside a live chat session, where the difference is
+        # a few gigabytes held for no reason.
+        base_model, base_tok = None, None
+        new_model, new_tok = None, None
+        training.release_model()

--- a/symbio/app/learn.py
+++ b/symbio/app/learn.py
@@ -64,6 +64,23 @@ _TOOL_ERROR_RE = re.compile(
 )
 
 
+_USER_REFUSAL_RE = re.compile(
+    r"\buser (?:denied|declined|refused|cancelled|canceled)\b", re.IGNORECASE)
+
+
+def is_user_refusal(observation: str) -> bool:
+    """Did this tool fail because the user said no?
+
+    A refusal reads as a tool error and is nothing like one. The retry path
+    exists for preconditions the model can fix by trying again — clicking
+    before the page was open — and there is no second attempt that makes a
+    "no" into a "yes". Retrying one only re-opens the same confirmation
+    prompt, so the user is made to decline the identical request twice in a
+    single turn, which reads as the agent not taking no for an answer.
+    """
+    return bool(_USER_REFUSAL_RE.search(observation.split("\n", 1)[0]))
+
+
 def sounds_like_tool_error(observation: str) -> bool:
     """Did a tool observation's status indicate failure? Checked against
     just the status line (before the first newline/section) so a genuine

--- a/symbio/app/memory.py
+++ b/symbio/app/memory.py
@@ -103,15 +103,19 @@ def save_skill(
 
 def list_skills() -> list[tuple[str, Path]]:
     """All saved skills as (title, path), detected by their '# Skill:' heading."""
-    skills = []
+    # Not `skills`: this module imports symbio.app.skills at the top, and a
+    # local of that name makes it unresolvable for the rest of the function.
+    # Harmless here only because nothing below touches the module — which is
+    # the same accident that made /skill-adapters unreachable in chat.py.
+    found = []
     for f in sorted(constants.NOTES_DIR.glob("*.md")):
         try:
             first_line = f.read_text(encoding="utf-8").splitlines()[0]
         except (OSError, IndexError):
             continue
         if first_line.lower().startswith("# skill:"):
-            skills.append((first_line[2:].strip(), f))
-    return skills
+            found.append((first_line[2:].strip(), f))
+    return found
 
 
 def _store_path(store: str) -> Path:

--- a/symbio/app/pending.py
+++ b/symbio/app/pending.py
@@ -1,0 +1,336 @@
+"""A durable record of work that can outlive the process running it.
+
+Everything expensive in Symbio is a fine-tune, and a fine-tune is minutes of
+GPU time that exists only in RAM until it writes an adapter. A skill saved with
+auto_train on runs its training on a daemon thread; a guarded run holds the
+previous adapter in a `.bak` directory it deletes on the way out. Neither of
+those survives the process dying, and the process dying is not hypothetical —
+a unified-memory Mac under an out-of-memory kill takes the whole session with
+it, mid-run, with no unwind and no chance to write anything down.
+
+What was lost was never the compute. It was the *knowledge that the work was
+owed*: on the next start nothing remembered that a skill had been seeded but
+never trained, or that an adapter directory was half-written with its only
+good copy sitting in an orphaned backup. This module writes that down as it
+happens, so a reboot resumes instead of restarting.
+
+Deliberately not a scheduler. Nothing here runs a task; it records that one is
+owed, notices when its owner died, and repairs what a dead owner left behind.
+Deciding to spend ten minutes of GPU on a recovered fine-tune stays with the
+operator, because starting one unprompted at boot is a fair description of how
+the machine went down in the first place.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from symbio import constants
+
+
+PENDING_FILE_NAME = "pending_tasks.json"
+
+
+def pending_file() -> Path:
+    """Where the journal lives, resolved per call rather than at import.
+
+    Binding this once at module load would read constants.LOG_DIR before a
+    test (or anything else redirecting the project's directories) could point
+    it somewhere else, and a journal that ignores that redirection writes real
+    entries into the operator's actual list from a test run.
+    """
+    return constants.LOG_DIR / PENDING_FILE_NAME
+
+# Writers are chat commands, tool calls and the skill auto-train thread, so
+# the file has more than one writer in-process. Cross-process races are not
+# covered and do not need to be: a duplicate entry is repaired by recover(),
+# where a lost one would defeat the point of the file.
+_LOCK = threading.Lock()
+
+# States. A task is "running" while a live process owns it, "deferred" when
+# nothing owns it and it is waiting to be picked up again — either because
+# recovery found its owner dead, or because it was refused before it started
+# (no memory to run it safely) and refusing must not mean forgetting.
+RUNNING = "running"
+DEFERRED = "deferred"
+
+
+def _boot_id() -> str | None:
+    """An identifier that changes when the machine reboots.
+
+    A pid alone cannot answer "is the process that owned this task still
+    alive?" across a reboot: the kernel hands out low pids again from scratch,
+    so the pid of a trainer killed by Jetsam is very likely live again —
+    belonging to something else entirely — by the time anyone asks. Pairing it
+    with the boot time makes a stale claim unmistakable, which matters most in
+    exactly the case this module exists for.
+    """
+    try:
+        out = subprocess.run(["sysctl", "-n", "kern.boottime"],
+                             capture_output=True, text=True, timeout=5)
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    try:  # Linux fallback; harmless everywhere it does not exist.
+        for line in Path("/proc/stat").read_text(encoding="utf-8").splitlines():
+            if line.startswith("btime "):
+                return line.strip()
+    except OSError:
+        pass
+    return None
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # Someone else's process, but a real one.
+    except OSError:
+        return True  # Unreadable is not evidence of death.
+    return True
+
+
+def _read() -> list[dict[str, Any]]:
+    path = pending_file()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        # A truncated file is exactly what a crash mid-write leaves behind.
+        # Losing the journal is bad; letting it take the session down with a
+        # parse error every start is worse.
+        return []
+    tasks = data.get("tasks") if isinstance(data, dict) else data
+    return [t for t in tasks if isinstance(t, dict)] if isinstance(tasks, list) else []
+
+
+def _write(tasks: list[dict[str, Any]]) -> None:
+    """Replace the journal atomically.
+
+    A partial write here would be its own kind of data loss, and this file is
+    written from the same processes that get killed abruptly. Rename is the
+    only step that is atomic, so the new content is complete on disk before
+    anything points at it.
+    """
+    path = pending_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    payload = json.dumps({"tasks": tasks}, indent=2)
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(payload)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def open_task(kind: str, detail: str, role: str | None = None,
+              **extra: Any) -> str:
+    """Record that this process is starting a piece of expensive work.
+
+    Returns an id to pass to finish()/update(). Written before the work
+    begins, because a record created after the fact does not survive the
+    failure it is for.
+    """
+    task_id = f"{kind}-{os.getpid()}-{datetime.now():%Y%m%d%H%M%S%f}"
+    task = {
+        "id": task_id,
+        "kind": kind,
+        "role": role,
+        "detail": detail,
+        "state": RUNNING,
+        "pid": os.getpid(),
+        "boot": _boot_id(),
+        "started": _now(),
+        "updated": _now(),
+        "attempts": int(extra.pop("attempts", 0)) + 1,
+    }
+    task.update(extra)
+    with _LOCK:
+        tasks = _read()
+        # Starting this work is what an outstanding entry for it was asking
+        # for, so the new run supersedes it rather than sitting beside it —
+        # otherwise every retry of a repeatedly-deferred fine-tune leaves
+        # another line on a list nobody can then trust. The attempt count
+        # carries over so a run that keeps failing still says so.
+        superseded = [t for t in tasks
+                      if t.get("kind") == kind and t.get("role") == role
+                      and t.get("state") == DEFERRED]
+        if superseded:
+            task["attempts"] += max(int(t.get("attempts", 1)) for t in superseded)
+            tasks = [t for t in tasks if t not in superseded]
+        tasks.append(task)
+        _write(tasks)
+    return task_id
+
+
+def update(task_id: str, **fields: Any) -> None:
+    """Attach facts learned after the task started — most importantly the
+    adapter backup directory, which is unknown until the snapshot is taken and
+    is the only thing that can undo a half-written adapter."""
+    with _LOCK:
+        tasks = _read()
+        for task in tasks:
+            if task.get("id") == task_id:
+                task.update(fields)
+                task["updated"] = _now()
+                _write(tasks)
+                return
+
+
+def finish(task_id: str) -> None:
+    """Drop a task that completed — whether it succeeded or failed cleanly.
+
+    A failure that returned is not unfinished business: it reported itself and
+    left the adapter in a known state. Only work whose owner vanished without
+    saying anything is owed on the next start.
+    """
+    with _LOCK:
+        tasks = [t for t in _read() if t.get("id") != task_id]
+        _write(tasks)
+
+
+def defer(kind: str, detail: str, role: str | None = None,
+          reason: str = "", **extra: Any) -> str:
+    """Record work that was refused before it ran, so refusing it is not the
+    same as dropping it.
+
+    The memory preflight declines a fine-tune it cannot run safely, which is
+    correct and, on its own, silent: the run simply never happened and nothing
+    remembered it was wanted. Deferred tasks are listed at start-up and can be
+    resumed once whatever was holding the memory is gone.
+    """
+    task_id = open_task(kind, detail, role=role, **extra)
+    update(task_id, state=DEFERRED, reason=reason, pid=None)
+    return task_id
+
+
+def all_tasks() -> list[dict[str, Any]]:
+    return _read()
+
+
+def _is_orphan(task: dict[str, Any], boot: str | None) -> bool:
+    if task.get("state") != RUNNING:
+        return False
+    if task.get("boot") and boot and task["boot"] != boot:
+        return True  # The machine rebooted under it.
+    pid = task.get("pid")
+    if not isinstance(pid, int):
+        return True
+    if pid == os.getpid():
+        return False  # Ours, and still running.
+    return not _pid_alive(pid)
+
+
+def orphaned() -> list[dict[str, Any]]:
+    """Tasks whose owning process is gone without having finished."""
+    boot = _boot_id()
+    return [t for t in _read() if _is_orphan(t, boot)]
+
+
+def deferred() -> list[dict[str, Any]]:
+    return [t for t in _read() if t.get("state") == DEFERRED]
+
+
+def outstanding() -> list[dict[str, Any]]:
+    """Everything owed: orphaned work plus work that was never started."""
+    boot = _boot_id()
+    return [t for t in _read()
+            if t.get("state") == DEFERRED or _is_orphan(t, boot)]
+
+
+def recover(restore_fn=None) -> list[str]:
+    """Repair what dead owners left behind and return a line per finding.
+
+    Two different things happen here. The repair is automatic: an orphaned run
+    may have left a half-written adapter directory beside a complete backup of
+    the last good one, and there is no reading of "resume" under which keeping
+    the truncated copy is right. Re-running the *training* is not automatic —
+    it is minutes of GPU and a second full copy of the weights, which is the
+    load that took the machine down. That decision is reported, not made.
+    """
+    boot = _boot_id()
+    messages: list[str] = []
+    with _LOCK:
+        tasks = _read()
+        changed = False
+        for task in tasks:
+            if not _is_orphan(task, boot):
+                continue
+            changed = True
+            task["state"] = DEFERRED
+            task["pid"] = None
+            task["reason"] = "owning process died before it finished"
+            task["updated"] = _now()
+            label = task.get("detail") or task.get("kind", "task")
+            backup = task.get("backup_dir")
+            if backup and restore_fn is not None and Path(backup).exists():
+                try:
+                    restore_fn(Path(backup), task.get("role"))
+                    task["restored_from_backup"] = backup
+                    # The backup stays on disk. It has done its job, but
+                    # deleting adapter weights on the strength of a repair
+                    # nobody has looked at yet is not a call this should make
+                    # unattended — so it is named instead of orphaned, which
+                    # is the difference between a spare copy and the
+                    # unexplained .bak directories a crash used to leave.
+                    messages.append(
+                        f"{label}: interrupted mid-run; restored the adapter "
+                        f"from the backup it left behind. That backup is kept "
+                        f"at {backup} — delete it once you are happy.")
+                    continue
+                except Exception as exc:
+                    messages.append(
+                        f"{label}: interrupted mid-run and its adapter backup "
+                        f"at {backup} could not be restored ({exc}). The "
+                        f"backup is still there.")
+                    continue
+            messages.append(f"{label}: interrupted before it finished.")
+        if changed:
+            _write(tasks)
+    return messages
+
+
+def describe_outstanding() -> list[str]:
+    """One human-readable line per piece of owed work."""
+    lines = []
+    for task in outstanding():
+        detail = task.get("detail") or task.get("kind", "task")
+        reason = task.get("reason")
+        attempts = task.get("attempts", 1)
+        line = f"{detail}"
+        if reason:
+            line += f" — {reason}"
+        if attempts > 1:
+            line += f" (attempt {attempts})"
+        lines.append(line)
+    return lines
+
+
+def clear(kind: str | None = None, role: str | None = None) -> int:
+    """Forget recorded tasks, optionally only those matching kind/role.
+
+    No argument means all of them. Returns how many were dropped.
+    """
+    def matches(task: dict[str, Any]) -> bool:
+        return ((kind is None or task.get("kind") == kind)
+                and (role is None or task.get("role") == role))
+
+    with _LOCK:
+        tasks = _read()
+        keep = [t for t in tasks if not matches(t)]
+        _write(keep)
+        return len(tasks) - len(keep)

--- a/symbio/app/skill_eval.py
+++ b/symbio/app/skill_eval.py
@@ -97,6 +97,22 @@ class ArmResult:
         return round(self.pass_count / self.total, 4) if self.total else 0.0
 
 
+def _step_body(text: str) -> str:
+    """The steps with their "1. " "2. " enumerators removed.
+
+    The numbers are structure, not content, and counting them as keywords
+    hands free credit to any numbered list. Measured on the knife-sharpening
+    skill: the base model answered with a completely different procedure —
+    whetstone, clean the blade, honing rod — and scored 68% against a
+    threshold of 60%, so it passed. Five of its 26 matches were the bare
+    digits 1-5. The adapter's own score is unaffected (it reproduces the
+    steps), so this only stops the baseline being flattered, which is the
+    number the whole comparison rests on.
+    """
+    parts = split_steps(text)
+    return " ".join(parts) if parts else text
+
+
 def _keywords(text: str) -> list[str]:
     """Content words from a skill's steps, deduped, order preserved.
 
@@ -263,7 +279,7 @@ def skill_golden_cases(name: str, steps: str) -> list[Any]:
 
     if not steps.strip():
         return []
-    keywords = _keywords(steps)
+    keywords = _keywords(_step_body(steps))
     if not keywords:
         return []
 
@@ -502,7 +518,7 @@ def run_skill_eval(
     if not steps:
         raise ValueError(f"Skill '{name}' has no recoverable steps to grade against.")
 
-    keywords = _keywords(steps)
+    keywords = _keywords(_step_body(steps))
     tasks, custom = load_tasks(role, name)
     adapter_dir = constants.adapter_dir_for(role)
     adapter_present = adapter_is_usable(adapter_dir)

--- a/symbio/app/skills.py
+++ b/symbio/app/skills.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from symbio import constants
-from symbio.app import dispatch, memory, training
+from symbio.app import dispatch, memory, pending, training
 
 
 NOTES_USAGE_FILE = constants.NOTES_DIR / ".last_used.json"
@@ -448,6 +448,15 @@ def save_skill_adapter(
         "trained": False,
         "message": f"Skill '{name}' saved as worker role '{role}' with {seeded} seed samples.",
     }
+
+    # The seeds are on disk and the adapter is not: from this line until a
+    # training run finishes, the skill is real but cannot answer from its own
+    # weights. Written down before the thread starts and before the crash
+    # window opens — guarded_train_worker supersedes this entry when it picks
+    # the work up, and clears it when it finishes, so a skill can never end up
+    # permanently seeded-but-untrained without something saying so.
+    pending.defer("train_worker", f"first adapter for skill '{name}'",
+                  role=role, reason="skill saved; adapter not trained yet")
 
     if auto_train:
         # Training the headmaster-sized model blocks for minutes; run in the

--- a/symbio/app/training.py
+++ b/symbio/app/training.py
@@ -1955,6 +1955,45 @@ def _training_overhead(config: dict[str, Any]) -> float:
     ]
 
 
+# A load-and-generate needs the weights plus a KV cache, with no optimiser
+# state and no retained activations, so it sits far below any of the training
+# multipliers above. Kept above 1.0 for the same reason those are pessimistic:
+# refusing a load costs a retry, accepting one the machine cannot hold costs
+# the machine.
+_INFERENCE_OVERHEAD = 1.25
+
+
+def load_memory_shortfall(config: dict[str, Any],
+                          model_name: str | None = None,
+                          purpose: str = "load this model") -> str | None:
+    """A message explaining why there is not room to load a model for
+    inference, or None to proceed.
+
+    _memory_shortfall guards the trainer child, which is only half of what a
+    guarded training run puts in RAM: the baseline and post-training golden
+    runs load their own full copy of the weights in *this* process, and did so
+    with no check at all. On a machine already holding the headmaster and a
+    resident worker, that unchecked load is the allocation that goes over the
+    edge — and it happens before the trainer's own preflight ever runs.
+    """
+    if not config.get("gpu", {}).get("memory_preflight", True):
+        return None
+    weights = _model_weight_bytes(model_name or config.get("model_name"))
+    free = free_ram_bytes()
+    if weights is None or free is None:
+        return None  # Unknown on either side is not evidence of a problem.
+    needed = int(weights * _INFERENCE_OVERHEAD)
+    if free >= needed:
+        return None
+    return (
+        f"Not enough free memory to {purpose}: it needs about "
+        f"{needed / 1e9:.1f} GB ({weights / 1e9:.1f} GB of weights plus a KV "
+        f"cache) and only {free / 1e9:.1f} GB is free. Something else is "
+        f"holding memory — a resident chat model, another worker, or a "
+        f"training run. Skipping rather than risking an out-of-memory kill."
+    )
+
+
 def _memory_shortfall(config: dict[str, Any],
                       model_name: str | None = None) -> str | None:
     """A message explaining why there is not room to train, or None to proceed.
@@ -2269,16 +2308,54 @@ def backup_adapter(role: str | None = None, label: str | None = None) -> Path | 
     backup_dir = adapter_dir.parent / f"{stem}.bak"
     if backup_dir.exists():
         backup_dir = adapter_dir.parent / f"{stem}.{datetime.now():%H%M%S_%f}.bak"
-    shutil.copytree(adapter_dir, backup_dir)
+    shutil.copytree(adapter_dir, backup_dir, ignore=_ignore_nested_workers)
     return backup_dir
 
 
+def _ignore_nested_workers(directory, names):
+    """Keep every worker's adapter out of the headmaster's snapshot.
+
+    The worker adapters live *inside* the headmaster's directory
+    (adapters/workers/<role>), so a plain copytree of adapters/ sweeps them
+    all into the headmaster's backup — and the matching restore then puts that
+    frozen copy back over whatever the workers have learned since. One
+    headmaster rollback would silently revert every skill adapter on the
+    machine to whenever its snapshot was taken, and delete outright any skill
+    trained after it. Worker adapters have their own backups, taken and
+    restored against their own directories; they have no business in this one.
+    """
+    if Path(directory).resolve() != constants.ADAPTER_DIR.resolve():
+        return set()
+    return {n for n in names if n == constants.WORKER_ADAPTERS_DIR.name}
+
+
 def restore_adapter(backup_dir: Path, role: str | None = None):
-    """Replace the current adapter with a previously backed-up one."""
+    """Replace the current adapter with a previously backed-up one.
+
+    Everything the adapter directory holds is replaced except the nested
+    workers/ tree, which belongs to the workers and is left exactly as it is.
+    Older backups, taken before backup_adapter learned to skip it, still carry
+    a stale copy of that tree; it is ignored rather than restored.
+    """
     adapter_dir = constants.adapter_dir_for(role)
+    workers_dir = constants.WORKER_ADAPTERS_DIR if role is None else None
     if adapter_dir.exists():
-        shutil.rmtree(adapter_dir)
-    shutil.copytree(backup_dir, adapter_dir)
+        for item in adapter_dir.iterdir():
+            if workers_dir is not None and item.name == workers_dir.name:
+                continue
+            if item.is_dir():
+                shutil.rmtree(item, ignore_errors=True)
+            else:
+                item.unlink(missing_ok=True)
+    adapter_dir.mkdir(parents=True, exist_ok=True)
+    for item in Path(backup_dir).iterdir():
+        if workers_dir is not None and item.name == workers_dir.name:
+            continue
+        target = adapter_dir / item.name
+        if item.is_dir():
+            shutil.copytree(item, target)
+        else:
+            shutil.copy2(item, target)
 
 
 def discard_adapter_backup(backup_dir: Path | None):

--- a/test_cli.py
+++ b/test_cli.py
@@ -114,3 +114,46 @@ def test_cli_archive_list_empty(isolated_cli, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Archived notes: 0" in out
     assert "Archived adapters: 0" in out
+
+
+# ---- `symb train <skill>` must use the same guarded path as everything else ----
+#
+# It called run_training directly, so a worker trained from the CLI got no
+# golden baseline, no rollback on regression, and no journal update. Observed:
+# a skill trained this way finished on disk while still listed as owed.
+
+def test_symb_train_skill_goes_through_the_guarded_path(monkeypatch, tmp_path):
+    from symbio import constants
+    from symbio.app import cli as _cli
+    from symbio.app import dispatch as _dispatch
+    from symbio.app import config as _config
+
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    catalog = tmp_path / "worker_models.json"
+    catalog.write_text('{"s": {"model_name": "m/s", "role": "fix_wifi", "is_skill": true}}')
+    monkeypatch.setattr(constants, "WORKER_MODELS_FILE", catalog)
+
+    guarded, raw = [], []
+    monkeypatch.setattr(_dispatch, "guarded_train_worker",
+                        lambda role, cfg, **kw: (guarded.append((role, kw)), (True, "ok"))[1])
+    monkeypatch.setattr(_cli, "run_training", lambda *a, **k: raw.append(k) or True)
+
+    rc = _cli._cmd_train(_config.load_config(), skill="fix wifi", iters=7)
+
+    assert rc == 0
+    assert guarded == [("fix_wifi", {"iters": 7, "resume": False})]
+    assert raw == [], "the unguarded trainer must not be called for a worker"
+
+
+def test_symb_train_without_a_skill_still_trains_the_headmaster(monkeypatch, tmp_path):
+    from symbio.app import cli as _cli
+    from symbio.app import dispatch as _dispatch
+    from symbio.app import config as _config
+
+    guarded, raw = [], []
+    monkeypatch.setattr(_dispatch, "guarded_train_worker",
+                        lambda *a, **k: guarded.append(a) or (True, "ok"))
+    monkeypatch.setattr(_cli, "run_training", lambda *a, **k: raw.append(k) or True)
+
+    assert _cli._cmd_train(_config.load_config()) == 0
+    assert raw and guarded == [], "the headmaster has its own path"

--- a/test_dispatch.py
+++ b/test_dispatch.py
@@ -4,11 +4,12 @@ task execution, the <delegate> tag, and guarded_train_worker's golden-check
 + rollback story for a worker's own adapter."""
 
 import json
+from pathlib import Path
 
 import pytest
 
 from symbio import constants
-from symbio.app import chat, dispatch, golden, tooling, training
+from symbio.app import chat, dispatch, golden, pending, tooling, training
 from symbio.app import config as app_config
 
 
@@ -206,6 +207,151 @@ def _make_session(config, monkeypatch):
     )
 
 
+def test_a_new_session_reports_and_repairs_what_the_last_one_left(
+        monkeypatch, tmp_path):
+    """The whole point, end to end: a session that was killed mid-training
+    leaves a record and a backup, and the next session — before it has even
+    loaded a model — puts the adapter back and says what is still owed."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+
+    task_id = pending.open_task(
+        "train_headmaster", "training for the headmaster adapter")
+    backup = tmp_path / "adapters.OLD.bak"
+    backup.mkdir()
+    (backup / "adapter_config.json").write_text("the last good adapter")
+    pending.update(task_id, backup_dir=str(backup), pid=0x7FFFFFFF)
+
+    printed = []
+    monkeypatch.setattr(chat, "load", lambda *a, **k: (object(), FakeTokenizer()))
+    chat.ChatSession(
+        app_config.load_config(), model=object(), tokenizer=FakeTokenizer(),
+        adapter_loaded=False, output_fn=printed.append,
+        generate_fn=lambda *a, **k: "unused",
+    )
+
+    assert (constants.ADAPTER_DIR / "adapter_config.json").read_text() == (
+        "the last good adapter"), "the half-written adapter must be replaced"
+    assert any("interrupted mid-run" in line for line in printed)
+    assert any("/resume" in line for line in printed)
+    assert len(pending.outstanding()) == 1, "the training itself is still owed"
+
+
+def test_resume_run_retrains_the_worker_that_was_owed(monkeypatch, tmp_path):
+    """Listing is the default because a fine-tune is minutes of GPU and a
+    second copy of the weights — the load that took the machine down. Running
+    it stays an explicit act."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+    })
+    pending.defer("train_worker", "first adapter for skill 'Summarize'",
+                  role="summarize", reason="not enough free memory")
+
+    retrained = []
+    monkeypatch.setattr(dispatch, "guarded_train_worker",
+                        lambda role, cfg, **k: (retrained.append(role), (True, "done"))[1])
+    printed = []
+    monkeypatch.setattr(chat, "load", lambda *a, **k: (object(), FakeTokenizer()))
+    session = chat.ChatSession(
+        app_config.load_config(), model=object(), tokenizer=FakeTokenizer(),
+        adapter_loaded=False, output_fn=printed.append,
+        generate_fn=lambda *a, **k: "unused",
+    )
+
+    # Through _handle_command, not _cmd_resume: `cmd` there is the whole
+    # input line rather than the first word, so a command registered with an
+    # equality test answers its bare form and drops every argument. Calling
+    # the method directly cannot see that — /resume run reached the user as
+    # "Unknown command" with these assertions passing.
+    session._handle_command("/resume")
+    assert retrained == [], "listing must not start a fine-tune"
+
+    session._handle_command("/resume run")
+    assert retrained == ["summarize"]
+
+
+def test_resume_clear_drops_the_carried_over_work(monkeypatch, tmp_path):
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    pending.defer("train_worker", "adapter for 'x'", role="x")
+
+    monkeypatch.setattr(chat, "load", lambda *a, **k: (object(), FakeTokenizer()))
+    session = chat.ChatSession(
+        app_config.load_config(), model=object(), tokenizer=FakeTokenizer(),
+        adapter_loaded=False, output_fn=lambda *a: None,
+        generate_fn=lambda *a, **k: "unused",
+    )
+
+    session._handle_command("/resume clear")
+    assert pending.outstanding() == []
+
+
+def test_listing_skills_does_not_break_listing_skill_adapters(
+        monkeypatch, tmp_path):
+    """Found by using the CLI rather than by testing it. /skills bound a local
+    named `skills`, which makes that name local to the whole of
+    _handle_command — so /skill-adapters, hundreds of lines below in the same
+    function, raised UnboundLocalError before running a line of its own, and
+    the exception took the entire chat session down with it. Neither command
+    had any coverage."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(chat, "load", lambda *a, **k: (object(), FakeTokenizer()))
+    printed = []
+    session = chat.ChatSession(
+        app_config.load_config(), model=object(), tokenizer=FakeTokenizer(),
+        adapter_loaded=False, output_fn=printed.append,
+        generate_fn=lambda *a, **k: "unused",
+    )
+
+    session._handle_command("/skills")
+    session._handle_command("/skill-adapters")
+
+    assert any("skill adapter" in line.lower() for line in printed)
+
+
+def test_a_refusal_blocks_a_different_tool_reaching_the_same_end(
+        monkeypatch, tmp_path):
+    """Observed live, not in a test: browser_open was denied at the domain
+    prompt, and the next round the model ran `open -a 'Google Chrome'` through
+    run_command and reported success — Chrome really did launch. The sandbox
+    is a denylist and `open` was never on it, but the gate the user answered
+    was about the action, not about which tool asked."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(chat, "load", lambda *a, **k: (object(), FakeTokenizer()))
+    session = chat.ChatSession(
+        app_config.load_config(), model=object(), tokenizer=FakeTokenizer(),
+        adapter_loaded=False, output_fn=lambda *a: None,
+        generate_fn=lambda *a, **k: "",
+    )
+
+    replies = iter([
+        "Opening apple.com. <browse>www.apple.com</browse>",
+        "Opening Chrome. <cmd>open -a 'Google Chrome'</cmd>",
+        "You declined, so I did not open it.",
+    ])
+    monkeypatch.setattr(session, "_generate_reply",
+                        lambda *a, **k: (next(replies, "Done."), False))
+
+    executed = []
+
+    def fake_execute(name, params):
+        executed.append(name)
+        if name == "browser_open":
+            return "Browser open blocked: User denied access to 'www.apple.com'."
+        return "Command 'open -a 'Google Chrome'' exited ok."
+
+    monkeypatch.setattr(session, "_execute_tool", fake_execute)
+    session._agent_turn("open apple.com for me")
+
+    assert executed == ["browser_open"], (
+        f"a declined action must not be reachable through another tool, "
+        f"but these ran: {executed}")
+
+
 def test_execute_tool_delegate_disabled_by_default(monkeypatch, tmp_path):
     _isolate_dirs(monkeypatch, tmp_path)
     config = app_config.load_config()
@@ -252,7 +398,7 @@ def test_guarded_train_worker_no_prior_adapter_trains_without_golden_check(monke
     })
     monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
     monkeypatch.setattr(training, "run_training",
-                        lambda cfg, iters=None, role=None, model_name=None:
+                        lambda cfg, iters=None, role=None, model_name=None, resume=False:
                             _write_worker_adapter(role, "trained") or True)
 
     config = app_config.load_config()
@@ -260,6 +406,219 @@ def test_guarded_train_worker_no_prior_adapter_trains_without_golden_check(monke
     assert trained is True
     assert "trained" in msg.lower()
     assert (constants.adapter_dir_for("summarize") / "adapter_config.json").exists()
+
+
+def test_guarded_train_worker_refuses_the_baseline_load_without_room(
+        monkeypatch, tmp_path):
+    """run_training's preflight only guards the trainer child. The baseline
+    golden run loads a second full copy of the weights in *this* process,
+    before that preflight ever runs — and auto-train does it on a background
+    thread while the headmaster is still resident. That load was unchecked."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+    })
+    _write_worker_adapter("summarize", "original")
+
+    load_calls = []
+    monkeypatch.setattr(dispatch, "load", _fake_load_factory(load_calls))
+    monkeypatch.setattr(training, "load_memory_shortfall",
+                        lambda cfg, model_name=None, purpose="": "No room.")
+    monkeypatch.setattr(training, "run_training",
+                        lambda *a, **k: pytest.fail("must not spawn a trainer"))
+
+    trained, msg = dispatch.guarded_train_worker("summarize", app_config.load_config())
+
+    assert trained is False
+    assert "No room." in msg
+    assert load_calls == [], "the refused copy must never have been loaded"
+    assert (constants.adapter_dir_for("summarize")
+            / "adapter_config.json").read_text() == "original"
+
+
+def test_a_refused_training_run_stays_on_the_books(monkeypatch, tmp_path):
+    """Refusing must not mean forgetting. The preflight declines a run it
+    cannot do safely, and without a record that is indistinguishable from the
+    training never having been wanted — which is how a skill ends up seeded
+    and permanently untrained."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+    })
+    _write_worker_adapter("summarize", "original")
+    monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
+    monkeypatch.setattr(training, "load_memory_shortfall",
+                        lambda cfg, model_name=None, purpose="": "No room.")
+
+    trained, _ = dispatch.guarded_train_worker("summarize", app_config.load_config())
+
+    assert trained is False
+    owed = pending.outstanding()
+    assert len(owed) == 1
+    assert owed[0]["role"] == "summarize"
+    assert "memory" in owed[0]["reason"]
+
+
+def test_work_for_a_deleted_role_stops_being_owed(monkeypatch, tmp_path):
+    """Deleting a skill used to leave an immortal entry: the unknown-role
+    return happens before the task is opened, so nothing ever finished it.
+    It reappeared at every start and /resume run could not clear it — only
+    /resume clear, which drops everything else with it."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    _write_catalog(monkeypatch, tmp_path, {})
+    pending.defer("train_worker", "first adapter for skill 'Gone'", role="gone")
+
+    trained, msg = dispatch.guarded_train_worker("gone", app_config.load_config())
+
+    assert trained is False
+    assert "No worker configured" in msg
+    assert pending.outstanding() == [], "an impossible task must not survive"
+
+
+def test_other_roles_survive_dropping_a_deleted_one(monkeypatch, tmp_path):
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    _write_catalog(monkeypatch, tmp_path, {})
+    pending.defer("train_worker", "adapter for 'gone'", role="gone")
+    pending.defer("train_worker", "adapter for 'kept'", role="kept")
+
+    dispatch.guarded_train_worker("gone", app_config.load_config())
+
+    assert [t["role"] for t in pending.outstanding()] == ["kept"]
+
+
+def test_a_run_that_produced_no_adapter_stays_owed(monkeypatch, tmp_path):
+    """Found by trialling five skills: four were seeded and none trained,
+    because the headmaster was resident and run_training's own preflight
+    refused. Every one returned False, and the blanket finish() in the
+    `finally` deleted the record — so four skills sat seeded and permanently
+    untrained with nothing owed and no warning at the next start. That is the
+    exact state this journal exists to make impossible."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+    })
+    monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
+    # What a refused preflight looks like from here: no adapter written.
+    monkeypatch.setattr(training, "run_training", lambda *a, **k: False)
+
+    trained, msg = dispatch.guarded_train_worker("summarize", app_config.load_config())
+
+    assert trained is False
+    owed = pending.outstanding()
+    assert len(owed) == 1, "a skill that never trained is still owed"
+    assert owed[0]["role"] == "summarize"
+    assert "memory" in owed[0]["reason"]
+
+
+def test_a_regressed_but_completed_run_is_not_owed(monkeypatch, tmp_path):
+    """A rollback is a verdict on the result, not an unfinished run."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+    })
+    _write_worker_adapter("summarize", "original")
+    monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
+    monkeypatch.setattr(training, "run_training",
+                        lambda cfg, iters=None, role=None, model_name=None, resume=False:
+                            _write_worker_adapter(role, "regressed") or True)
+    scores = iter([golden.GoldenResult({"c": True}, {}),
+                   golden.GoldenResult({"c": False}, {}),
+                   golden.GoldenResult({"c": False}, {})])
+    monkeypatch.setattr(golden, "run_golden_set",
+                        lambda *a, **k: next(scores, golden.GoldenResult({"c": False}, {})))
+    monkeypatch.setattr(golden, "run_golden_set_retry",
+                        lambda *a, **k: (golden.GoldenResult({"c": False}, {}), {"c"}))
+    monkeypatch.setattr(golden, "append_golden_remedy_samples",
+                        lambda *a, **k: 0)
+
+    trained, msg = dispatch.guarded_train_worker("summarize", app_config.load_config())
+
+    assert trained is True
+    assert pending.outstanding() == []
+
+
+def test_a_completed_training_run_leaves_nothing_owed(monkeypatch, tmp_path):
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+    })
+    monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
+    monkeypatch.setattr(training, "run_training",
+                        lambda cfg, iters=None, role=None, model_name=None, resume=False:
+                            _write_worker_adapter(role, "trained") or True)
+
+    trained, _ = dispatch.guarded_train_worker("summarize", app_config.load_config())
+
+    assert trained is True
+    assert pending.outstanding() == []
+    assert pending.all_tasks() == []
+
+
+def test_a_training_run_records_the_backup_it_is_relying_on(monkeypatch, tmp_path):
+    """While the run is in flight the previous adapter exists only inside the
+    backup directory. If nothing writes that path down, a process killed in
+    that window leaves an orphan nobody can identify."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path / "logs")
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+    })
+    _write_worker_adapter("summarize", "original")
+    monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
+    monkeypatch.setattr(golden, "run_golden_set",
+                        lambda *a, **k: golden.GoldenResult({"c": True}, {}))
+
+    seen = {}
+
+    def capture_then_die(cfg, iters=None, role=None, model_name=None, resume=False):
+        seen.update({t["id"]: t for t in pending.all_tasks()})
+        raise RuntimeError("killed mid-run")
+
+    monkeypatch.setattr(training, "run_training", capture_then_die)
+
+    with pytest.raises(RuntimeError):
+        dispatch.guarded_train_worker("summarize", app_config.load_config())
+
+    in_flight = list(seen.values())
+    assert len(in_flight) == 1
+    assert in_flight[0]["backup_dir"], "the live backup must be recorded"
+    assert Path(in_flight[0]["backup_dir"]).name.endswith(".bak")
+
+
+def test_guarded_train_worker_rolls_back_when_it_cannot_verify(
+        monkeypatch, tmp_path):
+    """Memory can run out between the trainer exiting and the check reloading.
+    An adapter that could not be golden-checked is not one to ship."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+    })
+    _write_worker_adapter("summarize", "original")
+    monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
+    monkeypatch.setattr(golden, "run_golden_set",
+                        lambda *a, **k: golden.GoldenResult({"c": True}, {}))
+    monkeypatch.setattr(training, "run_training",
+                        lambda cfg, iters=None, role=None, model_name=None, resume=False:
+                            _write_worker_adapter(role, "unverifiable") or True)
+
+    checks = []
+    monkeypatch.setattr(
+        training, "load_memory_shortfall",
+        lambda cfg, model_name=None, purpose="": (
+            checks.append(purpose) or ("No room." if len(checks) > 1 else None)))
+
+    trained, msg = dispatch.guarded_train_worker("summarize", app_config.load_config())
+
+    assert trained is False
+    assert "rolled back" in msg.lower()
+    assert (constants.adapter_dir_for("summarize")
+            / "adapter_config.json").read_text() == "original"
 
 
 def test_guarded_train_worker_regression_rolls_back(monkeypatch, tmp_path):
@@ -271,7 +630,7 @@ def test_guarded_train_worker_regression_rolls_back(monkeypatch, tmp_path):
 
     monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
     monkeypatch.setattr(training, "run_training",
-                        lambda cfg, iters=None, role=None, model_name=None:
+                        lambda cfg, iters=None, role=None, model_name=None, resume=False:
                             _write_worker_adapter(role, "regressed") or True)
 
     calls = []
@@ -303,7 +662,7 @@ def test_guarded_train_worker_regression_remedies_then_succeeds(monkeypatch, tmp
 
     train_calls = []
 
-    def fake_run_training(cfg, iters=None, role=None, model_name=None):
+    def fake_run_training(cfg, iters=None, role=None, model_name=None, resume=False):
         train_calls.append(iters)
         _write_worker_adapter(role, "remedied" if iters else "regressed")
         return True
@@ -480,7 +839,7 @@ def test_train_worker_command_trains_named_role(monkeypatch, tmp_path):
     })
     monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
     monkeypatch.setattr(training, "run_training",
-                        lambda cfg, iters=None, role=None, model_name=None:
+                        lambda cfg, iters=None, role=None, model_name=None, resume=False:
                             _write_worker_adapter(role, "trained") or True)
 
     config = app_config.load_config()
@@ -718,6 +1077,53 @@ def test_deep_sleep_allows_a_headmaster_sized_worker(monkeypatch, tmp_path):
 
     assert pool.get("alpha") is not None
     assert len(load_calls) == 1
+
+
+def test_deep_sleep_drops_the_worker_before_waking_the_headmaster(
+        monkeypatch, tmp_path):
+    """The OOM this was written for: deep sleep unloaded the headmaster before
+    the worker loaded, then reloaded it in the `finally` while the worker was
+    still resident — so both models were in RAM anyway, one turn later than
+    before. Deep sleep also switches off the second-copy refusal, so nothing
+    else was left to catch it."""
+    pool, _ = _refusal_pool(
+        monkeypatch, tmp_path, {"headmaster_deep_sleep_while_workers": True})
+    monkeypatch.setattr(dispatch, "generate", lambda *a, **k: "done")
+    monkeypatch.setattr(dispatch.training, "append_chat_pair",
+                        lambda *a, **k: None)
+
+    resident_when_headmaster_woke = []
+    pool.before_worker_fn = lambda: None
+    pool.after_worker_fn = lambda: resident_when_headmaster_woke.extend(
+        pool.loaded_roles())
+
+    pool.run_delegated_task("alpha", "do the thing")
+
+    assert resident_when_headmaster_woke == [], (
+        "the worker must be unloaded before the headmaster reloads")
+    assert pool.loaded_roles() == []
+
+
+def test_evicting_a_worker_hands_the_memory_back(monkeypatch, tmp_path):
+    """Dropping the dict entry is not freeing the weights: MLX keeps them
+    charged to the process until the allocator reclaims, so an eviction that
+    skips release_model() leaves the old worker resident right through the
+    load of its replacement."""
+    _isolate_dirs(monkeypatch, tmp_path)
+    _write_catalog(monkeypatch, tmp_path, {
+        "s": {"model_name": "m/s", "role": "summarize"},
+        "b": {"model_name": "m/b", "role": "browser"},
+    })
+    monkeypatch.setattr(dispatch, "load", _fake_load_factory([]))
+    released = []
+    monkeypatch.setattr(dispatch.training, "release_model",
+                        lambda: released.append(True))
+
+    pool = dispatch.WorkerPool({"dispatch": {"max_resident_workers": 1}})
+    pool.get("summarize")
+    assert released == [], "nothing evicted yet"
+    pool.get("browser")  # evicts summarize
+    assert released, "the evicted worker's memory must be released before the load"
 
 
 def test_the_second_copy_can_be_allowed_explicitly(monkeypatch, tmp_path):

--- a/test_pending.py
+++ b/test_pending.py
@@ -1,0 +1,217 @@
+"""Tests for the durable task journal (symbio.app.pending).
+
+The behaviour under test is what happens when a process does *not* get to run
+its cleanup: an out-of-memory kill takes a training run mid-flight, and the
+next start has to work out on its own that the work is owed and that the only
+intact copy of the adapter is sitting in a backup directory. Every test here
+simulates that by writing a journal entry and then never finishing it.
+"""
+
+import json
+import os
+
+import pytest
+
+from symbio import constants
+from symbio.app import pending
+
+
+@pytest.fixture(autouse=True)
+def journal(monkeypatch, tmp_path):
+    """Point the journal at a scratch directory.
+
+    pending.pending_file() is resolved per call precisely so this works — an
+    import-time constant would have every test in the suite appending to the
+    operator's real list of unfinished work.
+    """
+    monkeypatch.setattr(constants, "LOG_DIR", tmp_path)
+    return tmp_path / pending.PENDING_FILE_NAME
+
+
+# ---- the happy path leaves nothing behind ----
+
+def test_a_finished_task_is_forgotten():
+    task_id = pending.open_task("train_worker", "training 'summarize'", role="summarize")
+    assert len(pending.all_tasks()) == 1
+
+    pending.finish(task_id)
+
+    assert pending.all_tasks() == []
+    assert pending.outstanding() == []
+
+
+def test_a_task_owned_by_this_live_process_is_not_orphaned():
+    """Our own in-flight work is not carried-over work, or every session would
+    report the run it is in the middle of as something it needs to resume."""
+    pending.open_task("train_worker", "training 'summarize'", role="summarize")
+
+    assert pending.orphaned() == []
+    assert pending.outstanding() == []
+
+
+# ---- the crash path ----
+
+def _kill_the_owner(journal_path, **overrides):
+    """Rewrite the journal so its task looks like it belongs to a dead process."""
+    data = json.loads(journal_path.read_text(encoding="utf-8"))
+    data["tasks"][0].update(overrides)
+    journal_path.write_text(json.dumps(data), encoding="utf-8")
+    return data["tasks"][0]
+
+
+def test_a_task_whose_owner_died_is_owed(journal):
+    pending.open_task("train_worker", "training 'summarize'", role="summarize")
+    # A pid that cannot exist: the kernel rejects it rather than reporting a
+    # live process, so this is "definitely gone" rather than "probably".
+    _kill_the_owner(journal, pid=0x7FFFFFFF)
+
+    assert len(pending.orphaned()) == 1
+    assert len(pending.outstanding()) == 1
+
+
+def test_a_reboot_orphans_the_task_even_when_the_pid_is_reused(journal):
+    """The case this was written for. Jetsam kills the process, the machine
+    reboots, and the kernel hands out low pids from scratch — so the pid of the
+    dead trainer is very likely alive again, belonging to something else. A pid
+    check alone would call that task healthy forever."""
+    pending.open_task("train_worker", "training 'summarize'", role="summarize")
+    _kill_the_owner(journal, pid=os.getpid(), boot="a previous boot")
+
+    assert len(pending.orphaned()) == 1
+
+
+def test_recovery_restores_the_adapter_the_dead_run_was_replacing(journal):
+    """A killed trainer leaves a half-written adapter directory next to a
+    complete backup of the last good one. Keeping the truncated copy means
+    loading it as if it were trained."""
+    task_id = pending.open_task("train_worker", "training 'summarize'", role="summarize")
+    backup = constants.LOG_DIR / "summarize.bak"
+    backup.mkdir()
+    pending.update(task_id, backup_dir=str(backup))
+    _kill_the_owner(journal, pid=0x7FFFFFFF)
+
+    restored = []
+    messages = pending.recover(
+        restore_fn=lambda d, role: restored.append((d, role)))
+
+    assert restored == [(backup, "summarize")]
+    assert any("restored the adapter" in m for m in messages)
+    # A repair that leaves an unnamed .bak directory behind is how the
+    # unexplained backups in this project accumulated in the first place.
+    assert any(str(backup) in m for m in messages)
+    assert backup.exists(), "the spare copy is kept, not silently deleted"
+
+
+def test_recovery_reports_a_backup_it_could_not_restore(journal):
+    """Failing to repair is not a reason to drop the record — the backup is
+    still on disk and the operator needs to be told where."""
+    task_id = pending.open_task("train_worker", "training 'summarize'", role="summarize")
+    backup = constants.LOG_DIR / "summarize.bak"
+    backup.mkdir()
+    pending.update(task_id, backup_dir=str(backup))
+    _kill_the_owner(journal, pid=0x7FFFFFFF)
+
+    def boom(_dir, _role):
+        raise OSError("disk full")
+
+    messages = pending.recover(restore_fn=boom)
+
+    assert any("could not be restored" in m for m in messages)
+    assert any("disk full" in m for m in messages)
+    assert len(pending.outstanding()) == 1, "still owed"
+
+
+def test_recovery_is_idempotent(journal):
+    """Start, crash, start again, crash again: the second recovery must not
+    re-restore a backup the first one already put back."""
+    task_id = pending.open_task("train_worker", "training 'summarize'", role="summarize")
+    backup = constants.LOG_DIR / "summarize.bak"
+    backup.mkdir()
+    pending.update(task_id, backup_dir=str(backup))
+    _kill_the_owner(journal, pid=0x7FFFFFFF)
+
+    restored = []
+    pending.recover(restore_fn=lambda d, role: restored.append(d))
+    pending.recover(restore_fn=lambda d, role: restored.append(d))
+
+    assert len(restored) == 1
+    assert len(pending.outstanding()) == 1, "still owed until it is re-run"
+
+
+# ---- work that was refused before it started ----
+
+def test_deferred_work_is_owed_without_ever_having_run():
+    pending.defer("train_worker", "first adapter for skill 'X'", role="x",
+                  reason="not enough free memory")
+
+    owed = pending.outstanding()
+    assert len(owed) == 1
+    assert owed[0]["state"] == pending.DEFERRED
+    assert owed[0]["pid"] is None
+    assert "not enough free memory" in pending.describe_outstanding()[0]
+
+
+def test_starting_the_work_supersedes_the_entry_asking_for_it():
+    """Otherwise a fine-tune deferred five times leaves five lines describing
+    one piece of work, and the list stops being worth reading."""
+    pending.defer("train_worker", "first adapter for skill 'X'", role="x")
+    pending.defer("train_worker", "first adapter for skill 'X'", role="x")
+
+    task_id = pending.open_task("train_worker", "training 'x'", role="x")
+
+    assert len(pending.all_tasks()) == 1
+    assert pending.all_tasks()[0]["id"] == task_id
+    assert pending.all_tasks()[0]["attempts"] > 1, "the retries still count"
+
+    pending.finish(task_id)
+    assert pending.outstanding() == []
+
+
+def test_a_different_role_is_not_superseded():
+    pending.defer("train_worker", "adapter for 'a'", role="a")
+    pending.open_task("train_worker", "training 'b'", role="b")
+
+    assert len(pending.all_tasks()) == 2
+
+
+# ---- the journal itself has to survive the crash ----
+
+def test_a_truncated_journal_does_not_take_the_session_down(journal):
+    """The file is written by the processes that get killed abruptly. Losing
+    the list is bad; refusing to start every session afterwards is worse."""
+    journal.write_text('{"tasks": [{"id": "half', encoding="utf-8")
+
+    assert pending.all_tasks() == []
+    assert pending.recover() == []
+
+    # And it recovers as a working journal rather than staying poisoned.
+    task_id = pending.open_task("train_worker", "training 'summarize'")
+    assert [t["id"] for t in pending.all_tasks()] == [task_id]
+
+
+def test_the_journal_is_replaced_atomically(journal, monkeypatch):
+    """A crash during the write must leave the previous list intact, not a
+    truncated one — so the new content lands under a temporary name and the
+    rename is the only step that publishes it."""
+    pending.open_task("train_worker", "the first task", role="a")
+    before = journal.read_text(encoding="utf-8")
+
+    def die_before_publishing(src, dst):
+        raise OSError("killed mid-write")
+
+    monkeypatch.setattr(pending.os, "replace", die_before_publishing)
+    with pytest.raises(OSError):
+        pending.open_task("train_worker", "the second task", role="b")
+
+    assert journal.read_text(encoding="utf-8") == before
+
+
+def test_clear_drops_only_what_it_is_asked_to():
+    pending.defer("train_worker", "adapter for 'a'", role="a")
+    pending.defer("train_worker", "adapter for 'b'", role="b")
+    pending.defer("train_headmaster", "headmaster adapter")
+
+    assert pending.clear(kind="train_worker", role="a") == 1
+    assert {t["role"] for t in pending.all_tasks()} == {"b", None}
+    assert pending.clear() == 2
+    assert pending.all_tasks() == []

--- a/test_rag.py
+++ b/test_rag.py
@@ -98,3 +98,88 @@ def test_search_training_data_scans_recent_bytes_only(base_config, tmp_path):
     texts = [r["text"] for r in results]
     assert any("recent sample" in t for t in texts)
     assert not any("ancient" in t for t in texts)
+
+
+# ---- a wrong note is worse than no note ----
+#
+# Retrieved notes are pasted into the model's context, and skill notes are
+# procedures, so the model performs them. Measured live: a request to save a
+# bicycle skill retrieved the Browser Driver note and the agent produced a
+# repetition loop of "Clicking the Steps. Scrolling down." and a real
+# browser_open on google.com. IDF ranked correctly the whole time — it just
+# has no way to say "none of these", so when the topical words matched no note
+# the ranking fell to leftovers like "skill", "for" and "how".
+
+@pytest.fixture
+def skill_notes(base_config, tmp_path):
+    """A corpus shaped like the real one: procedures sharing boilerplate."""
+    notes = tmp_path / "notes"
+    bodies = {
+        "Skill__Browser_Driver.md": "# Skill: Browser Driver\n1. Click the element. 2. Scroll down. 3. Read the page.",
+        "Skill__Fix_wifi.md": "# Skill: Fix wifi\n1. Toggle the wifi adapter. 2. Forget the network. 3. Rejoin.",
+        "Skill__Coffee_Making.md": "# Skill: Coffee Making\n1. Grind beans. 2. Add filter. 3. Brew.",
+        "Skill__Device_Awareness.md": "# Skill: Device Awareness\n1. Save a fact when the user gives one. 2. Do arithmetic.",
+        "Skill__Researcher.md": "# Skill: Researcher\n1. Search online. 2. Summarise findings. 3. Cite sources.",
+        "Skill__Repotting.md": "# Skill: Repotting\n1. Check roots. 2. Choose a pot. 3. Water it.",
+    }
+    for name, text in bodies.items():
+        (notes / name).write_text(text, encoding="utf-8")
+    return Retriever(base_config)
+
+
+def test_a_query_matching_no_note_returns_nothing(skill_notes):
+    """Nothing here is about bicycles, so three confident wrong answers is the
+    one result that must not come back."""
+    assert skill_notes.search_notes("tuning a bicycle") == []
+    # The query that actually derailed the trial.
+    assert skill_notes.search_notes(
+        "Emit one <skill> tag for bicycle tuning. Write the steps yourself.") == []
+
+
+def test_a_real_shared_word_is_still_a_match(skill_notes):
+    """The floor drops notes with nothing distinguishing in common — not
+    notes that genuinely share a content word. "save" appears in the Device
+    Awareness note, so matching it is correct behaviour, not a regression."""
+    hits = skill_notes.search_notes("save a fact for me")
+    assert hits and "Device_Awareness" in hits[0]["title"]
+
+
+def test_the_word_skill_alone_retrieves_no_skill_note(skill_notes):
+    """It appears in every one of them, so it distinguishes nothing."""
+    assert skill_notes.search_notes("skill") == []
+    assert skill_notes.search_notes("what are the steps") == []
+
+
+def test_an_on_topic_query_still_finds_its_note(skill_notes):
+    hits = skill_notes.search_notes("how do I fix my wifi")
+    assert hits, "the floor must not suppress a real match"
+    assert "Fix_wifi" in hits[0]["title"]
+
+
+def test_every_skill_finds_its_own_note(skill_notes):
+    for query, expected in [("how do I make coffee", "Coffee_Making"),
+                            ("repotting a plant", "Repotting"),
+                            ("click the button and scroll", "Browser_Driver")]:
+        hits = skill_notes.search_notes(query)
+        assert hits and expected in hits[0]["title"], (query, hits)
+
+
+def test_stopwords_never_qualify_a_note(skill_notes):
+    """On a small technical corpus "how" and "do" are genuinely rare — most
+    notes are numbered steps and never use them — so a frequency test alone
+    called them discriminative and let them admit an unrelated note."""
+    terms = skill_notes._discriminative_terms(
+        ["how", "do", "the", "steps", "coffee"],
+        [["coffee"], ["a"], ["b"], ["c"], ["d"], ["e"]])
+    assert terms == {"coffee"}
+
+
+def test_a_small_corpus_keeps_the_old_behaviour(base_config, tmp_path):
+    """With four notes one is 25% and two is 50%, so the share cutoff would be
+    deciding on noise."""
+    notes = tmp_path / "notes"
+    for i in range(3):
+        (notes / f"n{i}.md").write_text(f"note {i} about widgets", encoding="utf-8")
+    r = Retriever(base_config)
+    assert r._discriminative_terms(["widgets"], [["a"], ["b"], ["c"]]) is None
+    assert r.search_notes("widgets"), "still finds things in a tiny corpus"

--- a/test_safety.py
+++ b/test_safety.py
@@ -143,3 +143,41 @@ def test_is_sensitive_config_key():
     assert safety.is_sensitive_config_key("remote.hosts")
     assert safety.is_sensitive_config_key("safety.enabled")
     assert not safety.is_sensitive_config_key("agent.temperature")
+
+
+# ---- a refusal is a decision, not a retryable failure ----
+#
+# Found by using the CLI: one denied browser_open put the identical
+# confirmation prompt in front of the user twice in the same turn, because a
+# denial matches sounds_like_tool_error and the retry path exists for
+# preconditions the model can fix. No retry turns a "no" into a "yes".
+
+from symbio.app import learn as _learn
+
+
+def test_a_denial_is_recognised_as_a_refusal():
+    assert _learn.is_user_refusal("User denied access to 'www.apple.com'.")
+    assert _learn.is_user_refusal("Browser open blocked: User denied access to 'x'.")
+    assert _learn.is_user_refusal("Command cancelled: user declined.")
+
+
+def test_a_refusal_still_reads_as_a_failed_call():
+    """The model must be told the call did not succeed — it just must not be
+    handed another attempt at it."""
+    assert _learn.sounds_like_tool_error(
+        "Browser open blocked: User denied access to 'www.apple.com'.")
+
+
+def test_an_ordinary_failure_is_not_a_refusal():
+    """The precondition failures the retry path was built for must keep it."""
+    assert not _learn.is_user_refusal(
+        "Browser click error: no element matching 'Sign in'.")
+    assert not _learn.is_user_refusal("Failed: page not open yet.")
+
+
+def test_content_mentioning_a_denial_is_not_a_refusal():
+    """Only the status line counts, so a search result about someone being
+    denied something does not disable retries for a successful call."""
+    assert not _learn.is_user_refusal(
+        "Search results:\nThe user denied the allegations in court.")
+

--- a/test_skill_eval.py
+++ b/test_skill_eval.py
@@ -477,3 +477,51 @@ def test_order_anchors_match_whole_tokens_only():
         "1. Unplug the unit. 2. Check the configuration.", steps) is None
     # Spelled as its own token, it counts.
     assert skill_eval.order_score("Unplug the unit, then switch On.", steps) == 1.0
+
+
+# ---- step numbers are structure, not vocabulary ----
+#
+# Measured on the knife-sharpening skill: the base model answered with a
+# completely different procedure (whetstone, clean the blade, honing rod) and
+# still scored 68% against a 60% threshold, so it passed. Five of its 26
+# matches were the bare digits 1-5, which any numbered list gets for free.
+# The adapter arm is unaffected — it reproduces the steps either way — so this
+# was only ever flattering the baseline the whole comparison rests on.
+
+_KNIFE = ("1. Hold the knife with the blade facing up. "
+          "2. Insert the blade into the sharpening rod at a 20-degree angle. "
+          "3. Slowly slide the blade along the rod. "
+          "4. Repeat on the other side. "
+          "5. Test the edge by slicing paper.")
+
+
+def test_step_numbers_are_not_keywords():
+    kws = skill_eval._keywords(skill_eval._step_body(_KNIFE))
+    assert not [k for k in kws if k.isdigit()], kws
+
+
+def test_numbers_inside_a_step_survive():
+    """"20-degree" is the procedure; "3." is the enumeration."""
+    kws = skill_eval._keywords(skill_eval._step_body(_KNIFE))
+    assert "20-degree" in kws
+
+
+def test_a_different_procedure_no_longer_passes_on_its_numbering():
+    """The actual base-model reply that passed."""
+    reply = ("Here are the steps to sharpen a kitchen knife: "
+             "1. Prepare the knife: ensure the knife is clean and dry. "
+             "2. Choose a sharpening tool: a whetstone, a honing rod, or a "
+             "manual sharpener. 3. Hold the blade at an angle and slide it "
+             "along the stone. 4. Repeat on the other side. "
+             "5. Test the edge by slicing paper.")
+    before = skill_eval.coverage(reply, skill_eval._keywords(_KNIFE))
+    after = skill_eval.coverage(
+        reply, skill_eval._keywords(skill_eval._step_body(_KNIFE)))
+    assert before >= skill_eval.DEFAULT_PASS_THRESHOLD, (
+        "this is the score that used to pass")
+    assert after < before, "dropping the enumerators must lower it"
+
+
+def test_the_real_procedure_still_scores_full_marks():
+    kws = skill_eval._keywords(skill_eval._step_body(_KNIFE))
+    assert skill_eval.coverage(_KNIFE, kws) == 1.0

--- a/test_training_loop.py
+++ b/test_training_loop.py
@@ -355,6 +355,37 @@ def test_the_preflight_can_be_switched_off(monkeypatch):
     assert training._memory_shortfall(_config(memory_preflight=False)) is None
 
 
+def test_a_plain_load_is_judged_by_what_a_load_costs(monkeypatch):
+    """The golden-check copies loaded around a training run carry no optimiser
+    state and no retained activations, so charging them the trainer's 3.6x
+    would refuse loads that fit several times over."""
+    monkeypatch.setattr(training, "_model_weight_bytes", lambda name: 4_000_000_000)
+    monkeypatch.setattr(training, "free_ram_bytes", lambda: 6_000_000_000)
+
+    assert training._memory_shortfall(_config()) is not None
+    assert training.load_memory_shortfall(_config()) is None
+
+
+def test_a_load_with_no_room_is_refused(monkeypatch):
+    monkeypatch.setattr(training, "_model_weight_bytes", lambda name: 4_000_000_000)
+    monkeypatch.setattr(training, "free_ram_bytes", lambda: 3_000_000_000)
+
+    message = training.load_memory_shortfall(_config(), purpose="check a worker")
+
+    assert message is not None
+    assert "check a worker" in message
+    assert "5.0 GB" in message and "3.0 GB" in message
+
+
+def test_the_load_preflight_honours_the_same_switches(monkeypatch):
+    monkeypatch.setattr(training, "free_ram_bytes", lambda: 1)
+    monkeypatch.setattr(training, "_model_weight_bytes", lambda name: 4_000_000_000)
+    assert training.load_memory_shortfall(_config(memory_preflight=False)) is None
+
+    monkeypatch.setattr(training, "_model_weight_bytes", lambda name: None)
+    assert training.load_memory_shortfall(_config()) is None
+
+
 def test_free_ram_counts_reclaimable_pages(monkeypatch):
     """Inactive pages are populated but available, so ignoring them would
     refuse to train on a machine that is actually idle."""
@@ -688,3 +719,88 @@ def test_checkpoint_interval_divides_the_evaluation_interval():
     lora = app_config.DEFAULT_CONFIG["lora"]
 
     assert lora["steps_per_eval"] % lora["save_every"] == 0
+
+
+# ---- adapter backup/restore must not swallow the worker adapters ----
+#
+# The workers live inside the headmaster's own directory
+# (adapters/workers/<role>), which made them collateral in every headmaster
+# rollback: the snapshot copied them in, and the restore put that frozen copy
+# back over everything they had learned since. Startup crash-recovery calls
+# restore_adapter unattended, so this ran without anyone watching.
+
+@pytest.fixture
+def adapter_tree(monkeypatch, tmp_path):
+    """A headmaster adapter with worker adapters nested underneath it."""
+    root = tmp_path / "adapters"
+    workers = root / "workers"
+    (workers / "researcher").mkdir(parents=True)
+    (root / "adapters.safetensors").write_text("headmaster v1")
+    (root / "adapter_config.json").write_text("{}")
+    (workers / "researcher" / "adapters.safetensors").write_text("researcher v1")
+    monkeypatch.setattr(constants, "ADAPTER_DIR", root)
+    monkeypatch.setattr(constants, "WORKER_ADAPTERS_DIR", workers)
+    monkeypatch.setattr(training, "adapter_label", lambda role=None: "HEADMASTER")
+    monkeypatch.setattr(training, "adapter_total_iters", lambda role=None: 125)
+    return root, workers
+
+
+def test_the_headmaster_backup_leaves_the_workers_out(adapter_tree):
+    root, _ = adapter_tree
+
+    backup = training.backup_adapter()
+
+    assert (backup / "adapters.safetensors").read_text() == "headmaster v1"
+    assert not (backup / "workers").exists(), (
+        "a headmaster snapshot must not carry copies of the worker adapters")
+
+
+def test_restoring_the_headmaster_does_not_touch_the_workers(adapter_tree):
+    root, workers = adapter_tree
+    backup = training.backup_adapter()
+    # Time passes: the headmaster retrains, and so does a worker.
+    (root / "adapters.safetensors").write_text("headmaster v2")
+    (workers / "researcher" / "adapters.safetensors").write_text("researcher v2")
+    (workers / "browser").mkdir()
+    (workers / "browser" / "adapters.safetensors").write_text("browser v1")
+
+    training.restore_adapter(backup)
+
+    assert (root / "adapters.safetensors").read_text() == "headmaster v1"
+    assert (workers / "researcher" / "adapters.safetensors").read_text() == (
+        "researcher v2"), "the worker's later training must survive"
+    assert (workers / "browser").exists(), (
+        "a worker trained after the snapshot must not be deleted by a "
+        "headmaster rollback")
+
+
+def test_an_older_backup_carrying_workers_does_not_restore_them(adapter_tree):
+    """Backups taken before this was fixed still have the stale tree inside —
+    including the one sitting in the project root right now."""
+    root, workers = adapter_tree
+    backup = root.parent / "adapters.OLD.bak"
+    (backup / "workers" / "researcher").mkdir(parents=True)
+    (backup / "adapters.safetensors").write_text("headmaster v0")
+    (backup / "workers" / "researcher" / "adapters.safetensors").write_text("stale")
+
+    training.restore_adapter(backup)
+
+    assert (root / "adapters.safetensors").read_text() == "headmaster v0"
+    assert (workers / "researcher" / "adapters.safetensors").read_text() == (
+        "researcher v1"), "the stale copy inside the backup must be ignored"
+
+
+def test_a_worker_restore_is_unaffected(adapter_tree):
+    """A worker's own directory has no nested tree to protect; its restore
+    must still replace everything it holds."""
+    root, workers = adapter_tree
+    monkeypatch_role = workers / "researcher"
+    backup = root.parent / "researcher.bak"
+    backup.mkdir()
+    (backup / "adapters.safetensors").write_text("researcher v0")
+    (monkeypatch_role / "stray.json").write_text("left over")
+
+    training.restore_adapter(backup, role="researcher")
+
+    assert (monkeypatch_role / "adapters.safetensors").read_text() == "researcher v0"
+    assert not (monkeypatch_role / "stray.json").exists()


### PR DESCRIPTION
Six findings from the out-of-memory crash, each reproduced by driving the CLI rather than by testing around it.

Deep sleep held two models anyway. run_delegated_task unloaded the headmaster before a worker ran, then reloaded it in the `finally` while the worker was still resident — the same double residency one turn later, with the second-copy guard switched off because deep sleep was on. The worker is now dropped before the headmaster comes back. Pool eviction was a bare `del`, so MLX kept the old weights charged straight through the load of its replacement; it now releases.

Refused work stopped being forgotten. guarded_train_worker's in-process golden loads had no memory preflight at all — run_training's guards only the trainer child, and auto-train runs on a daemon thread with the headmaster still up. A new journal (symbio/app/pending.py) records expensive work before it starts, survives a kill, and pairs pid with boot id so a reused pid after a reboot cannot look alive. Startup restores adapters that dead runs left half-written; /resume lists, runs or clears the rest. A run that produces no adapter now stays owed: five skills were seeded and four silently never trained because every refusal was reported into a log nobody reads.

A headmaster rollback used to eat the workers. Their adapters live inside the headmaster's own directory, and backup/restore was copytree/rmtree over the lot — recovery would have deleted three worker adapters and reverted a fourth by four days.

"No" was not final. A denied browser_open matched sounds_like_tool_error, so the retry path asked again in the same turn, and the next round the model reached the same end through run_command — the sandbox is a denylist and `open` was never on it. A refusal now blocks every later tool that turn and the reply says plainly it did not happen.

Retrieval could not say "none of these". IDF ranked correctly but `s > 0` admitted any note sharing a common word, so a query whose topical words matched nothing returned the three least-bad — and skill notes are procedures the model then performs. A bicycle question retrieved the Browser Driver note and produced real clicks on google.com. A note now has to share a term that is both rare and not a stopword.

Skill eval counted step numbers as vocabulary. The base model answered knife sharpening with a different procedure entirely and scored 68% against a 60% threshold, five of its matches being the bare digits 1-5. Corrected, the adapter arm is unchanged and the baseline falls: 30/30 vs 5/30 across six skills whose steps the model wrote itself.

Also: /skill-adapters could never run (a local named `skills` in /skills shadowed the module for the whole of _handle_command, and the UnboundLocalError took the session down), /resume dropped its arguments, and `symb train <skill>` bypassed the guarded path — no golden baseline, no rollback, no journal update.