### PR TITLE
Fix five defects found by measuring, and add the instruments that fou…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,44 @@ Symbio (for now) runs on Apple Silicon using MLX and Metal performance shaders
 ## Quick start
 
 ```bash
-# Create a virtual environment and install dependencies
-python -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-
-# Install `symbio` / `symb` as system-wide commands.
-# Editable install links the current repo so code edits take effect immediately:
-pip install -e .
-
-# First launch runs an interactive setup wizard:
-#   - set names, pick a model preset, choose speed mode
-#   - toggle browser, web search, MOA dispatch, Telegram
-#   - add Telegram bot token and allowed chat IDs
-symbio
-# Or the short alias:
-#   symb
-# Re-run the wizard anytime with:
-#   symb setup
+./install.sh
 ```
+
+That is the whole install. It checks you are on Apple silicon with enough RAM
+and disk, creates its own virtualenv, installs everything, fetches the browser
+engine, and then **drops you into a shell with the environment already
+active** — so there is nothing to remember to activate. Type `exit` to leave;
+your original shell is untouched.
+
+Then:
+
+```bash
+symbio        # or the short alias: symb
+```
+
+First launch runs an interactive setup wizard (names, model preset, speed mode,
+and toggles for browser, web search, MOA dispatch and Telegram), downloads the
+model, and spends ~25 seconds warming its prompt cache. Later starts take about
+a second, because that cache is saved to disk. Re-run the wizard any time with
+`symb setup`.
+
+<details>
+<summary>Install options</summary>
+
+```bash
+./install.sh --prefetch-model   # download the 4.1 GB model now, not on first run
+./install.sh --no-browser       # skip the ~150 MB Chromium download
+./install.sh --with-native      # include the experimental symbio_native extras
+./install.sh --dev              # include dev/test dependencies
+./install.sh --no-shell         # install only; do not enter the environment
+./install.sh --venv PATH        # put the virtualenv somewhere else
+```
+
+Requirements are checked before anything is downloaded: macOS on Apple silicon
+(MLX has no CPU fallback), Python 3.10+, ~8 GB free disk, and 16 GB of RAM for
+the default 8B model — less RAM works, but pick a smaller model in the wizard.
+
+</details>
 ## How it works
 
 1. **You talk to the AI** — Ask it anything

--- a/adapter_seal.py
+++ b/adapter_seal.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Weld an adapter to the training data it came from, and prove it later.
+
+    python3 adapter_seal.py seal    Adapter_skills/brew_tea_150_WORKER
+    python3 adapter_seal.py verify  Adapter_skills/brew_tea_150_WORKER
+    python3 adapter_seal.py seal-all
+    python3 adapter_seal.py verify-all
+    python3 adapter_seal.py challenge Adapter_skills/brew_tea_150_WORKER
+    python3 adapter_seal.py respond   Adapter_skills/... --nonce HEX
+
+HOW IT WORKS
+
+    data_digest    a Merkle root over the training files: each file hashed,
+                   the (name, hash) pairs sorted, then hashed together. Sorted
+                   so it does not depend on directory order; per-file so the
+                   report can say WHICH file moved.
+
+    adapter_digest sha256 of the weights.
+
+    pair_key       HKDF-SHA256 over (data_digest || adapter_digest). This is
+                   the weld: it can only be derived by someone holding both
+                   artifacts, unmodified. Change one byte of either and the
+                   key is different.
+
+    pair_commit    sha256(pair_key), written into the seal. Publishing the
+                   commitment rather than the key means the seal itself can
+                   never be used to forge a response.
+
+WHAT A PASSING VERIFY ACTUALLY PROVES
+
+That these exact weights and these exact training files are the ones sealed
+together, and neither has changed since. That is integrity and pairing.
+
+It does NOT prove the adapter was trained on that data. Nothing computed after
+the fact can: the weights do not carry a receipt of what produced them. The
+seal is a witness written at a moment in time, and it is worth exactly as much
+as that moment was. Seal at the end of a training run and it means a great
+deal; seal an adapter you found lying around and it means the two files were
+sitting next to each other when you said so.
+
+THE CHALLENGE
+
+`challenge` prints a random nonce. `respond` derives pair_key from the files
+on disk and returns HMAC(pair_key, nonce), which requires both artifacts —
+neither alone is enough, which is the "each unlocks it in turn" part. The
+verifier checks it by doing the same from its own copy. Since a nonce is never
+reused, a captured response cannot be replayed.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import secrets
+import sys
+from datetime import datetime
+from pathlib import Path
+
+SEAL_NAME = "provenance.json"
+HKDF_INFO = b"symbio-adapter-training-weld-v1"
+_CHUNK = 1 << 20
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(_CHUNK):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _training_files(folder: Path) -> list[Path]:
+    d = folder / "training_data"
+    if not d.is_dir():
+        return []
+    return sorted((p for p in d.rglob("*") if p.is_file()),
+                  key=lambda p: str(p.relative_to(d)))
+
+
+def _weights_file(folder: Path) -> Path | None:
+    """The archived weights, whatever they are called."""
+    man = folder / "manifest.json"
+    if man.exists():
+        try:
+            name = json.loads(man.read_text(encoding="utf-8")).get("weights")
+            if name and (folder / name).exists():
+                return folder / name
+        except json.JSONDecodeError:
+            pass
+    for p in sorted(folder.glob("*.safetensors")):
+        return p
+    return None
+
+
+def data_digest(folder: Path) -> tuple[str, dict[str, str]]:
+    """Merkle-ish root over the training files, plus the per-file hashes.
+
+    Per-file hashes are kept so a failed verify can name the file that moved
+    rather than only saying the data changed.
+    """
+    d = folder / "training_data"
+    per_file: dict[str, str] = {}
+    for p in _training_files(folder):
+        per_file[str(p.relative_to(d))] = _sha256_file(p)
+    root = hashlib.sha256()
+    for name in sorted(per_file):
+        root.update(name.encode("utf-8"))
+        root.update(bytes.fromhex(per_file[name]))
+    return root.hexdigest(), per_file
+
+
+def _hkdf_sha256(ikm: bytes, salt: bytes, info: bytes, length: int = 32) -> bytes:
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+    out, block, counter = b"", b"", 1
+    while len(out) < length:
+        block = hmac.new(prk, block + info + bytes([counter]), hashlib.sha256).digest()
+        out += block
+        counter += 1
+    return out[:length]
+
+
+def pair_key(data_hex: str, adapter_hex: str, salt_hex: str) -> bytes:
+    return _hkdf_sha256(bytes.fromhex(data_hex) + bytes.fromhex(adapter_hex),
+                        bytes.fromhex(salt_hex), HKDF_INFO)
+
+
+def _measure(folder: Path) -> dict:
+    weights = _weights_file(folder)
+    if weights is None:
+        raise FileNotFoundError(f"no .safetensors in {folder}")
+    d_hex, per_file = data_digest(folder)
+    return {
+        "weights_name": weights.name,
+        "adapter_digest": _sha256_file(weights),
+        "data_digest": d_hex,
+        "files": per_file,
+    }
+
+
+def seal(folder: Path, quiet: bool = False) -> int:
+    m = _measure(folder)
+    if not m["files"]:
+        print(f"  {folder.name}: no training_data/ — nothing to weld it to")
+        return 1
+    salt = secrets.token_hex(16)
+    key = pair_key(m["data_digest"], m["adapter_digest"], salt)
+    doc = {
+        "version": 1,
+        "sealed": datetime.now().isoformat(timespec="seconds"),
+        "weights_name": m["weights_name"],
+        "adapter_digest": m["adapter_digest"],
+        "data_digest": m["data_digest"],
+        "file_count": len(m["files"]),
+        "files": m["files"],
+        "salt": salt,
+        # The commitment, never the key: a seal that carried the key could be
+        # used to answer a challenge without holding either artifact.
+        "pair_commit": hashlib.sha256(key).hexdigest(),
+        "proves": ("These weights and these training files were sealed "
+                   "together and neither has changed since. Not that one was "
+                   "trained from the other — nothing after the fact can show "
+                   "that."),
+    }
+    (folder / SEAL_NAME).write_text(json.dumps(doc, indent=2) + "\n",
+                                    encoding="utf-8")
+    if not quiet:
+        print(f"  sealed {folder.name}")
+        print(f"    data     {m['data_digest'][:16]}  ({len(m['files'])} file(s))")
+        print(f"    adapter  {m['adapter_digest'][:16]}")
+        print(f"    weld     {doc['pair_commit'][:16]}")
+    return 0
+
+
+def verify(folder: Path, quiet: bool = False) -> int:
+    path = folder / SEAL_NAME
+    if not path.exists():
+        print(f"  {folder.name}: NOT SEALED")
+        return 1
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    m = _measure(folder)
+
+    problems: list[str] = []
+    if m["adapter_digest"] != doc["adapter_digest"]:
+        problems.append("adapter weights changed")
+    if m["data_digest"] != doc["data_digest"]:
+        sealed, now = doc.get("files", {}), m["files"]
+        for name in sorted(set(sealed) | set(now)):
+            if name not in now:
+                problems.append(f"training file removed: {name}")
+            elif name not in sealed:
+                problems.append(f"training file added: {name}")
+            elif sealed[name] != now[name]:
+                problems.append(f"training file changed: {name}")
+
+    if not problems:
+        key = pair_key(m["data_digest"], m["adapter_digest"], doc["salt"])
+        if hashlib.sha256(key).hexdigest() != doc["pair_commit"]:
+            problems.append("weld does not match the commitment")
+
+    if problems:
+        print(f"  {folder.name}: BROKEN")
+        for p in problems:
+            print(f"      {p}")
+        return 1
+    if not quiet:
+        print(f"  {folder.name}: intact "
+              f"({doc['file_count']} training file(s), sealed {doc['sealed']})")
+    return 0
+
+
+def challenge(folder: Path) -> int:
+    if not (folder / SEAL_NAME).exists():
+        print(f"  {folder.name} is not sealed")
+        return 1
+    nonce = secrets.token_hex(16)
+    print(f"  nonce: {nonce}")
+    print(f"  respond with: python3 {Path(__file__).name} respond "
+          f"{folder} --nonce {nonce}")
+    return 0
+
+
+def respond(folder: Path, nonce: str) -> int:
+    path = folder / SEAL_NAME
+    if not path.exists():
+        print(f"  {folder.name} is not sealed")
+        return 1
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    m = _measure(folder)
+    key = pair_key(m["data_digest"], m["adapter_digest"], doc["salt"])
+    proof = hmac.new(key, bytes.fromhex(nonce), hashlib.sha256).hexdigest()
+    print(f"  {proof}")
+    return 0
+
+
+def check_response(folder: Path, nonce: str, proof: str) -> int:
+    path = folder / SEAL_NAME
+    if not path.exists():
+        print(f"  {folder.name} is not sealed")
+        return 1
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    m = _measure(folder)
+    key = pair_key(m["data_digest"], m["adapter_digest"], doc["salt"])
+    expect = hmac.new(key, bytes.fromhex(nonce), hashlib.sha256).hexdigest()
+    ok = hmac.compare_digest(expect, proof.strip())
+    print(f"  {'ACCEPTED' if ok else 'REJECTED'}")
+    return 0 if ok else 1
+
+
+def _folders(root: Path) -> list[Path]:
+    out = root / "Adapter_skills"
+    if not out.is_dir():
+        return []
+    return sorted(p for p in out.iterdir() if p.is_dir())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("action", choices=["seal", "verify", "seal-all", "verify-all",
+                                       "challenge", "respond", "check"])
+    ap.add_argument("folder", nargs="?", help="an Adapter_skills/<NAME> folder")
+    ap.add_argument("--nonce")
+    ap.add_argument("--proof")
+    ap.add_argument("--root", default=str(Path(__file__).resolve().parent))
+    args = ap.parse_args()
+
+    if args.action in ("seal-all", "verify-all"):
+        folders = _folders(Path(args.root))
+        if not folders:
+            print("Nothing in Adapter_skills/. Run archive_adapters.py first.")
+            return 1
+        fn = seal if args.action == "seal-all" else verify
+        bad = sum(fn(f) != 0 for f in folders)
+        print(f"\n  {len(folders) - bad}/{len(folders)} ok")
+        return 1 if bad else 0
+
+    if not args.folder:
+        print(f"{args.action} needs a folder")
+        return 1
+    folder = Path(args.folder)
+    if args.action == "seal":
+        return seal(folder)
+    if args.action == "verify":
+        return verify(folder)
+    if args.action == "challenge":
+        return challenge(folder)
+    if args.action == "respond":
+        if not args.nonce:
+            print("respond needs --nonce")
+            return 1
+        return respond(folder, args.nonce)
+    if args.action == "check":
+        if not (args.nonce and args.proof):
+            print("check needs --nonce and --proof")
+            return 1
+        return check_response(folder, args.nonce, args.proof)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/archive_adapters.py
+++ b/archive_adapters.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Collect every adapter into one readable folder, with its data and metadata.
+
+    python3 archive_adapters.py                 # build Adapter_skills/
+    python3 archive_adapters.py --dry-run       # show what it would write
+    python3 archive_adapters.py --list          # what is in there now
+    python3 archive_adapters.py --restore NAME  # rebuild a loadable adapter dir
+
+Layout produced:
+
+    Adapter_skills/
+      HEADMASTER_600_HEADMASTER/
+        HEADMASTER_600.safetensors      the weights
+        adapter_config.json             metadata, as trained
+        training_progress.json
+        last_used.json
+        manifest.json                   where it came from, how to restore
+        training_data/train.jsonl       the data it was trained on
+        training_data/valid.jsonl
+      brew_loose_leaf_tea_150_WORKER/
+        brew_loose_leaf_tea_150.safetensors
+        ...
+
+WHY THIS IS AN ARCHIVE AND NOT THE LIVE LAYOUT
+
+mlx_lm hardcodes the filename it loads:
+
+    mlx_lm/tuner/utils.py: load_adapters()
+        model.load_weights(str(adapter_path / "adapters.safetensors"))
+
+An adapter file named anything else cannot be loaded — including at boot. So
+this copies rather than moves: adapters/ keeps working exactly as it does now,
+and Adapter_skills/ is the organised, browsable, portable version, named the
+way you asked. --restore turns any archived folder back into a directory
+mlx_lm will load, so nothing here is a one-way trip.
+
+Iterations come from adapter_config.json["iters"], falling back to
+training_progress.json["total_iters"], falling back to 0.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+ADAPTERS = WORKER_ADAPTERS = TRAINING = WORKER_TRAINING = OUT = Path()
+
+
+def set_root(root: Path) -> None:
+    """Point every path at `root`.
+
+    The default is the directory this script sits in, which is the project.
+    --root exists so it can be pointed at a checkout it does not live in —
+    which is also how it gets tested without a copy of the adapters.
+    """
+    global ROOT, ADAPTERS, WORKER_ADAPTERS, TRAINING, WORKER_TRAINING, OUT
+    ROOT = root.resolve()
+    ADAPTERS = ROOT / "adapters"
+    WORKER_ADAPTERS = ADAPTERS / "workers"
+    TRAINING = ROOT / "training_data"
+    WORKER_TRAINING = TRAINING / "workers"
+    OUT = ROOT / "Adapter_skills"
+
+
+set_root(Path(__file__).resolve().parent)
+
+WEIGHTS = "adapters.safetensors"
+META_FILES = ("adapter_config.json", "training_progress.json", "last_used.json")
+DATA_FILES = ("train.jsonl", "valid.jsonl")
+
+
+def _iters(adapter_dir: Path) -> int:
+    """How many iterations this adapter was trained for."""
+    cfg = adapter_dir / "adapter_config.json"
+    if cfg.exists():
+        try:
+            n = json.loads(cfg.read_text(encoding="utf-8")).get("iters")
+            if isinstance(n, int) and n > 0:
+                return n
+        except (json.JSONDecodeError, OSError):
+            pass
+    prog = adapter_dir / "training_progress.json"
+    if prog.exists():
+        try:
+            n = json.loads(prog.read_text(encoding="utf-8")).get("total_iters")
+            if isinstance(n, int) and n > 0:
+                return n
+        except (json.JSONDecodeError, OSError):
+            pass
+    return 0
+
+
+def _sources() -> list[tuple[str, str, Path, Path]]:
+    """(skill, kind, adapter_dir, training_dir) for everything worth archiving."""
+    found: list[tuple[str, str, Path, Path]] = []
+    if (ADAPTERS / WEIGHTS).exists():
+        found.append(("HEADMASTER", "HEADMASTER", ADAPTERS, TRAINING))
+    if WORKER_ADAPTERS.is_dir():
+        for d in sorted(p for p in WORKER_ADAPTERS.iterdir() if p.is_dir()):
+            if (d / WEIGHTS).exists():
+                found.append((d.name, "WORKER", d, WORKER_TRAINING / d.name))
+    return found
+
+
+def build(dry_run: bool = False) -> int:
+    sources = _sources()
+    if not sources:
+        print(f"No adapters found under {ADAPTERS}")
+        return 1
+
+    print(f"{'Would archive' if dry_run else 'Archiving'} {len(sources)} adapter(s) "
+          f"into {OUT}\n")
+    total_bytes = 0
+
+    for skill, kind, adapter_dir, training_dir in sources:
+        iters = _iters(adapter_dir)
+        folder = OUT / f"{skill}_{iters}_{kind}"
+        weights_name = f"{skill}_{iters}.safetensors"
+        size = (adapter_dir / WEIGHTS).stat().st_size
+        total_bytes += size
+
+        data_files = [f for f in DATA_FILES if (training_dir / f).exists()]
+        print(f"  {folder.name}")
+        print(f"      {weights_name}  ({size / 1e6:.1f} MB)")
+        print(f"      metadata: {', '.join(f for f in META_FILES if (adapter_dir / f).exists())}")
+        print(f"      training_data: {', '.join(data_files) or '(none found)'}")
+
+        if dry_run:
+            continue
+
+        folder.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(adapter_dir / WEIGHTS, folder / weights_name)
+        for f in META_FILES:
+            if (adapter_dir / f).exists():
+                shutil.copy2(adapter_dir / f, folder / f)
+        if data_files:
+            (folder / "training_data").mkdir(exist_ok=True)
+            for f in data_files:
+                shutil.copy2(training_dir / f, folder / "training_data" / f)
+
+        # Enough to put it back, and to know what it was without guessing from
+        # the folder name.
+        (folder / "manifest.json").write_text(json.dumps({
+            "skill": skill,
+            "kind": kind,
+            "iters": iters,
+            "weights": weights_name,
+            "archived": datetime.now().isoformat(timespec="seconds"),
+            "source_adapter_dir": str(adapter_dir),
+            "source_training_dir": str(training_dir),
+            "restore_hint": (
+                "Copy the .safetensors back as 'adapters.safetensors' beside "
+                "adapter_config.json — mlx_lm loads that exact filename. "
+                f"Or: python3 archive_adapters.py --restore {folder.name}"),
+        }, indent=2) + "\n", encoding="utf-8")
+
+    print(f"\n{'Would copy' if dry_run else 'Copied'} {total_bytes / 1e6:.0f} MB. "
+          f"adapters/ is untouched and still what the app loads.")
+    return 0
+
+
+def list_archive() -> int:
+    if not OUT.is_dir():
+        print(f"No archive yet. Run: python3 {Path(__file__).name}")
+        return 1
+    rows = []
+    for d in sorted(p for p in OUT.iterdir() if p.is_dir()):
+        man = d / "manifest.json"
+        info = {}
+        if man.exists():
+            try:
+                info = json.loads(man.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                pass
+        weights = d / info.get("weights", "")
+        size = weights.stat().st_size / 1e6 if weights.exists() else 0.0
+        rows.append((d.name, info.get("kind", "?"), info.get("iters", "?"), size))
+    width = max((len(r[0]) for r in rows), default=10)
+    for name, kind, iters, size in rows:
+        print(f"  {name:{width}}  {kind:10}  {iters:>6} iters  {size:6.1f} MB")
+    print(f"\n  {len(rows)} archived under {OUT}")
+    return 0
+
+
+def restore(name: str) -> int:
+    folder = OUT / name
+    man = folder / "manifest.json"
+    if not man.exists():
+        print(f"No archive named {name} (looked for {man})")
+        return 1
+    info = json.loads(man.read_text(encoding="utf-8"))
+    weights = folder / info["weights"]
+    if not weights.exists():
+        print(f"Archive is missing its weights: {weights}")
+        return 1
+
+    dest = ROOT / f"restored_{name}"
+    dest.mkdir(parents=True, exist_ok=True)
+    # The whole point: back to the filename mlx_lm insists on.
+    shutil.copy2(weights, dest / WEIGHTS)
+    for f in META_FILES:
+        if (folder / f).exists():
+            shutil.copy2(folder / f, dest / f)
+
+    print(f"Restored to {dest}")
+    print(f"  {WEIGHTS} + {', '.join(f for f in META_FILES if (dest / f).exists())}")
+    print("\nThis directory is loadable as-is:")
+    print(f"  load(model_name, adapter_path='{dest}')")
+    print("\nIt was NOT copied over adapters/ — moving a live adapter into place "
+          "is your call, and worth backing up first.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--dry-run", action="store_true", help="show, do not write")
+    ap.add_argument("--list", action="store_true", help="list what is archived")
+    ap.add_argument("--restore", metavar="NAME", help="rebuild a loadable dir")
+    ap.add_argument("--root", metavar="PATH",
+                    help="project directory (default: where this script lives)")
+    args = ap.parse_args()
+
+    if args.root:
+        set_root(Path(args.root))
+
+    if args.list:
+        return list_archive()
+    if args.restore:
+        return restore(args.restore)
+    return build(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/db_agent_test.py
+++ b/db_agent_test.py
@@ -1,0 +1,221 @@
+"""Can it actually drive a database, an AWS-ish worker, and a niche lookup?
+
+Harder than the tool battery. For the database cases this does not stop at
+"did it emit a plausible command" — it takes the command the model wrote,
+runs it against a throwaway copy of a real sqlite database, and checks the
+answer or the resulting rows. A command that parses but returns the wrong
+number fails here, which is the whole point.
+
+Nothing touches the user's data: every case runs against a fresh copy of
+shop.db in the job's tmp dir, and any command that is not a plain
+sqlite3/python invocation is refused rather than run.
+"""
+import importlib.util
+import json
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+MAIN = "/Users/huygpt/Downloads/agi"
+WT = MAIN + "/.claude/worktrees/symbio-kvcache-dispatch"
+TMP = Path("/Users/huygpt/.claude/jobs/f90be41f/tmp")
+MASTER_DB = TMP / "shop.db"
+sys.path.insert(0, MAIN)
+
+import symbio
+import symbio.app
+import symbio.constants
+
+
+def swap(modname, path):
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    setattr(symbio.app, modname.rsplit(".", 1)[1], mod)
+    return mod
+
+
+tooling = swap("symbio.app.tooling", WT + "/symbio/app/tooling.py")
+
+from mlx_lm import load, generate
+from mlx_lm.sample_utils import make_sampler
+from symbio.app import config as cfgmod, prompts
+
+# ---------------------------------------------------------------- safety
+# The model's own text gets executed below. Refuse anything that is not a
+# read/write against the throwaway database.
+# A whitelist, not a blacklist. The first attempt blacklisted shell
+# metacharacters and refused the model's perfectly correct
+#     sqlite3 shop.db "SELECT COUNT(*) FROM users;"
+# because SQL needs the semicolon. That scored a right answer as a failure.
+_DANGEROUS = re.compile(
+    r"\b(rm|mv|cp|chmod|chown|sudo|curl|wget|ssh|scp|kill|shutdown|dd|mkfs|"
+    r"launchctl|osascript|open|eval|exec)\b|[>|&`]|\$\(|\.\.")
+
+_ALLOWED_FIRST = {"sqlite3", "python", "python3"}
+
+
+def safe_to_run(cmd: str) -> bool:
+    parts = cmd.strip().split()
+    if not parts or parts[0] not in _ALLOWED_FIRST:
+        return False
+    return not _DANGEROUS.search(cmd)
+
+
+def fresh_db() -> Path:
+    d = Path(tempfile.mkdtemp(prefix="dbtest_", dir=TMP))
+    db = d / "shop.db"
+    shutil.copy2(MASTER_DB, db)
+    return db
+
+
+def run_sql(sql: str, db: Path) -> tuple[bool, str]:
+    """Execute SQL directly against the copy. Returns (ok, output)."""
+    try:
+        con = sqlite3.connect(db)
+        cur = con.executescript(sql) if ";" in sql.strip()[:-1] else con.execute(sql)
+        rows = cur.fetchall() if cur.description else []
+        con.commit()
+        con.close()
+        return True, "\n".join(str(r) for r in rows)
+    except Exception as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def safe_python(code: str) -> bool:
+    """Guard for CODE, not for a command line.
+
+    safe_to_run whitelists the first token against {sqlite3, python3}, which is
+    right for a shell command and wrong for a Python source file — that starts
+    with "import", so a perfectly good script was refused and scored as a model
+    failure. Code gets the dangerous-pattern check only.
+    """
+    return not _DANGEROUS.search(code)
+
+
+def run_python(code: str, db: Path) -> tuple[bool, str]:
+    if not safe_python(code):
+        return False, "refused: code touches something outside sqlite"
+    try:
+        p = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                           text=True, timeout=20, cwd=db.parent)
+        return p.returncode == 0, (p.stdout + p.stderr).strip()
+    except subprocess.TimeoutExpired:
+        return False, "timed out"
+
+
+def run_shell(cmd: str, db: Path) -> tuple[bool, str]:
+    if not safe_to_run(cmd):
+        return False, "refused: command contains something outside sqlite use"
+    try:
+        p = subprocess.run(cmd, shell=True, capture_output=True, text=True,
+                           timeout=20, cwd=db.parent)
+        return p.returncode == 0, (p.stdout + p.stderr).strip()
+    except subprocess.TimeoutExpired:
+        return False, "timed out"
+
+
+# ---------------------------------------------------------------- cases
+DB_PATH_HINT = "shop.db"
+
+DB_CASES = [
+    {
+        "id": "db_count_users",
+        "prompt": f"The sqlite database {DB_PATH_HINT} is in the current directory. "
+                  f"How many rows are in the users table? Use a tool to find out.",
+        "expect": lambda out, db: "3" in out,
+        "why": "3 users",
+    },
+    {
+        "id": "db_list_tables",
+        "prompt": f"List the tables in the sqlite database {DB_PATH_HINT} "
+                  f"in the current directory.",
+        "expect": lambda out, db: "users" in out.lower() and "orders" in out.lower(),
+        "why": "tables users and orders",
+    },
+    {
+        "id": "db_revenue",
+        "prompt": f"In the sqlite database {DB_PATH_HINT} in the current directory, "
+                  f"what is the total of the cents column in the orders table?",
+        "expect": lambda out, db: "52995" in out.replace(",", ""),
+        "why": "52995 cents",
+    },
+    {
+        "id": "db_insert",
+        "prompt": f"In the sqlite database {DB_PATH_HINT} in the current directory, "
+                  f"add a user named Dmitri with email dmitri@example.com.",
+        "expect": lambda out, db: sqlite3.connect(db).execute(
+            "SELECT COUNT(*) FROM users WHERE name='Dmitri'").fetchone()[0] == 1,
+        "why": "a Dmitri row exists afterwards",
+    },
+    {
+        "id": "db_join",
+        "prompt": f"In the sqlite database {DB_PATH_HINT} in the current directory, "
+                  f"which user spent the most? Give the name.",
+        "expect": lambda out, db: "bob" in out.lower(),
+        "why": "Bob, 24999",
+    },
+]
+
+
+def extract_command(reply: str):
+    """(kind, payload) for the first executable thing in the reply."""
+    for name, params in tooling.parse_tools(reply):
+        if name == "execute_code" and params.get("code"):
+            return "python", params["code"]
+        if name in ("run_command", "run_remote") and params.get("cmd"):
+            return "shell", params["cmd"]
+    return None, None
+
+
+def main():
+    cfg = cfgmod.load_config()
+    model, tok = load(cfg["model_name"], adapter_path=str(symbio.constants.ADAPTER_DIR))
+    sp = prompts.build_system_prompt(cfg["assistant_name"], cfg["user_name"])
+    sampler = make_sampler(temp=cfg["agent"]["temperature"], top_p=cfg["agent"]["top_p"])
+    print(f"model loaded; {len(DB_CASES)} database cases\n", flush=True)
+
+    passed = 0
+    for case in DB_CASES:
+        db = fresh_db()
+        messages = [{"role": "system", "content": sp + prompts.env_note()},
+                    {"role": "user", "content": case["prompt"]}]
+        prompt = tok.apply_chat_template(messages, tokenize=False,
+                                         add_generation_prompt=True,
+                                         enable_thinking=False)
+        reply = generate(model, tok, prompt=prompt, sampler=sampler,
+                         max_tokens=250, verbose=False).strip()
+        kind, payload = extract_command(reply)
+
+        print(f"[{case['id']}] expect: {case['why']}", flush=True)
+        print(f"  reply: {' '.join(reply.split())[:150]}", flush=True)
+
+        if kind is None:
+            print("  RESULT: no executable tool call\n", flush=True)
+            continue
+
+        print(f"  emitted {kind}: {' '.join(payload.split())[:130]}", flush=True)
+        if kind == "python":
+            ok, out = run_python(payload, db)
+        else:
+            ok, out = run_shell(payload, db)
+        print(f"  ran -> ok={ok}  out={' '.join(out.split())[:110]}", flush=True)
+
+        try:
+            good = bool(case["expect"](out, db))
+        except Exception as e:
+            good = False
+            out = f"{out} (check raised {e})"
+        print(f"  RESULT: {'PASS' if good else 'FAIL'}\n", flush=True)
+        passed += good
+
+    print(f"\n==== DATABASE CONTROL: {passed}/{len(DB_CASES)} ====")
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1,66 +1,218 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Symbio install script.
-# Keeps symbio_native/ by default. Remove it with --skip-native or SKIP_NATIVE=1.
+# Symbio installer.
+#
+# One command, from a clean machine:
+#
+#     ./install.sh
+#
+# It creates its own virtualenv, installs into it, fetches the browser engine,
+# and tells you exactly what to run next. Safe to re-run.
+#
+# The previous version assumed you had already made and activated a venv and
+# went straight to `pip install -e`. On a current macOS that either fails with
+# PEP 668 ("externally-managed-environment") or quietly installs into the
+# system Python, which is worse. Everything below exists because it was a way
+# the install could fail without saying why.
 
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_ROOT"
 
-SKIP_NATIVE="${SKIP_NATIVE:-0}"
-KEEP_NATIVE="${KEEP_NATIVE:-0}"
-INTERACTIVE="${INTERACTIVE:-auto}"
+VENV="${SYMBIO_VENV:-$REPO_ROOT/venv}"
+WITH_NATIVE="${WITH_NATIVE:-0}"
+WITH_BROWSER="${WITH_BROWSER:-1}"
+PREFETCH_MODEL="${PREFETCH_MODEL:-0}"
+DEV="${DEV:-0}"
+ENTER_SHELL="${ENTER_SHELL:-1}"
+
+RED=$'\033[31m'; YEL=$'\033[33m'; GRN=$'\033[32m'; DIM=$'\033[2m'; OFF=$'\033[0m'
+say()  { printf '%s\n' "$*"; }
+ok()   { printf '%s  ok%s  %s\n' "$GRN" "$OFF" "$*"; }
+warn() { printf '%s warn%s %s\n' "$YEL" "$OFF" "$*"; }
+die()  { printf '%s fail%s %s\n' "$RED" "$OFF" "$*" >&2; exit 1; }
 
 usage() {
-    echo "Usage: $0 [--skip-native] [--keep-native]"
-    echo "  --skip-native   Remove symbio_native/ before installing"
-    echo "  --keep-native   Keep symbio_native/ without prompting"
-    echo "  SKIP_NATIVE=1   Same as --skip-native"
-    echo "  KEEP_NATIVE=1   Same as --keep-native"
+    cat <<'EOF'
+Usage: ./install.sh [options]
+
+  --with-native      Also install the experimental symbio_native extras
+  --no-browser       Skip the Playwright browser download (~150 MB)
+  --prefetch-model   Download the 4.1 GB model now instead of on first run
+  --dev              Include dev/test dependencies
+  --no-shell         Do not drop into the environment when finished
+  --venv PATH        Use a different virtualenv path (default: ./venv)
+  -h, --help         This message
+
+Environment equivalents: WITH_NATIVE=1 WITH_BROWSER=0 PREFETCH_MODEL=1 DEV=1
+                         ENTER_SHELL=0
+EOF
     exit 0
 }
 
-for arg in "$@"; do
-    case "$arg" in
-        --skip-native) SKIP_NATIVE=1 ;;
-        --keep-native) KEEP_NATIVE=1 ;;
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --with-native) WITH_NATIVE=1 ;;
+        --no-browser) WITH_BROWSER=0 ;;
+        --prefetch-model) PREFETCH_MODEL=1 ;;
+        --dev) DEV=1 ;;
+        --no-shell) ENTER_SHELL=0 ;;
+        --venv) shift; VENV="${1:?--venv needs a path}" ;;
         -h|--help) usage ;;
+        *) die "unknown option: $1 (try --help)" ;;
     esac
+    shift
 done
 
-echo "=== Symbio installer ==="
+say "=== Symbio installer ==="
+say ""
 
-if [ "$SKIP_NATIVE" = "1" ]; then
-    echo "SKIP_NATIVE set -> removing symbio_native/"
-    rm -rf symbio_native
-elif [ "$KEEP_NATIVE" = "1" ]; then
-    echo "KEEP_NATIVE set -> keeping symbio_native/"
+# ---------------------------------------------------------------- preflight
+# Checked up front, because every one of these otherwise surfaces as a
+# confusing error several minutes into a large download.
+
+case "$(uname -s)" in
+    Darwin) ;;
+    *) die "Symbio runs on macOS. MLX is Apple-silicon only, and there is no
+       CPU fallback — this will not work on $(uname -s)." ;;
+esac
+
+if [ "$(uname -m)" != "arm64" ]; then
+    die "Apple silicon required (found $(uname -m)). MLX needs an M-series chip;
+       an Intel Mac cannot run this."
+fi
+ok "macOS on Apple silicon ($(uname -m))"
+
+PY="${PYTHON:-python3}"
+command -v "$PY" >/dev/null 2>&1 || die "no python3 on PATH. Install it with: brew install python@3.12"
+
+# `|| echo 0` matters: under `set -e` a python that exists but cannot run
+# (wrong arch, broken symlink, a shim that exits non-zero) would abort the
+# script on this line with no message at all — the installer would simply
+# stop, mid-preflight, looking like it had finished.
+PY_OK="$("$PY" -c 'import sys; print(1 if sys.version_info >= (3,10) else 0)' 2>/dev/null || echo 0)"
+[ "$PY_OK" = "1" ] || die "need a working Python 3.10+. \`$PY\` reported: $("$PY" -V 2>&1 || echo 'it failed to run at all')
+       Try: brew install python@3.12   (or set PYTHON=/path/to/python3)"
+ok "$("$PY" -V 2>&1)"
+
+# The model alone is 4.1 GB, plus ~1.5 GB of wheels. Fail now, not at 90%.
+NEED_GB=8
+FREE_GB="$(df -g . | awk 'NR==2 {print $4}')"
+if [ "${FREE_GB:-0}" -lt "$NEED_GB" ]; then
+    die "need ~${NEED_GB} GB free, found ${FREE_GB} GB.
+       The model is 4.1 GB and the Python packages are ~1.5 GB."
+fi
+ok "${FREE_GB} GB free"
+
+TOTAL_RAM_GB="$(( $(sysctl -n hw.memsize) / 1024 / 1024 / 1024 ))"
+if [ "$TOTAL_RAM_GB" -lt 16 ]; then
+    warn "${TOTAL_RAM_GB} GB of RAM. The default 8B model wants 16 GB;
+       pick a smaller model in the setup wizard or it will swap badly."
 else
-    # Try interactive prompt; fall back to keeping native if no TTY.
-    if [ "$INTERACTIVE" = "auto" ] && [ -t 0 ] && [ -t 1 ]; then
-        read -rp "Keep the experimental symbio_native model? [Y/n] " answer < /dev/tty || true
-        case "${answer:-Y}" in
-            [Nn]*)
-                echo "Removing symbio_native/"
-                rm -rf symbio_native
-                ;;
-            *)
-                echo "Keeping symbio_native/"
-                KEEP_NATIVE=1
-                ;;
-        esac
-    else
-        echo "No TTY detected -> keeping symbio_native/ by default (use --skip-native to remove)"
-        KEEP_NATIVE=1
+    ok "${TOTAL_RAM_GB} GB RAM"
+fi
+
+say ""
+
+# ------------------------------------------------------------------- venv
+# Made here rather than assumed, so a clean machine needs exactly one command
+# and nobody has to remember to activate anything first.
+if [ -d "$VENV" ]; then
+    ok "reusing virtualenv at $VENV"
+else
+    say "  creating virtualenv at $VENV"
+    "$PY" -m venv "$VENV" || die "could not create a virtualenv at $VENV"
+    ok "virtualenv created"
+fi
+
+VPY="$VENV/bin/python"
+[ -x "$VPY" ] || die "virtualenv looks broken: no $VPY. Remove $VENV and re-run."
+
+say "  upgrading pip"
+"$VPY" -m pip install --quiet --upgrade pip
+
+# ---------------------------------------------------------------- install
+EXTRAS=""
+if [ "$WITH_NATIVE" = "1" ] && [ "$DEV" = "1" ]; then EXTRAS="[native,dev]"
+elif [ "$WITH_NATIVE" = "1" ]; then EXTRAS="[native]"
+elif [ "$DEV" = "1" ]; then EXTRAS="[dev]"
+fi
+
+say "  installing symbio${EXTRAS} ${DIM}(a few minutes; torch alone is ~535 MB)${OFF}"
+"$VPY" -m pip install --quiet -e ".${EXTRAS}" || die "pip install failed. Full output:
+       $VPY -m pip install -e \".${EXTRAS}\""
+ok "symbio installed"
+
+# ---------------------------------------------------------------- browser
+# Playwright ships a Python package and a separate browser binary. Installing
+# only the first leaves every browser tool failing at runtime with a message
+# about a missing executable, long after the install "succeeded".
+if [ "$WITH_BROWSER" = "1" ]; then
+    if "$VPY" -c 'import playwright' 2>/dev/null; then
+        say "  installing the Chromium engine for browser tools (~150 MB)"
+        if "$VPY" -m playwright install chromium >/dev/null 2>&1; then
+            ok "browser engine installed"
+        else
+            warn "could not install the Chromium engine. Browser tools will not work
+       until you run: $VPY -m playwright install chromium"
+        fi
     fi
-fi
-
-if [ -d symbio_native ]; then
-    echo "Installing with native model dependencies..."
-    pip install -e ".[native,dev]"
 else
-    echo "Installing without native model dependencies..."
-    pip install -e ".[dev]"
+    warn "skipping the browser engine (--no-browser). Browser tools will not work
+       until you run: $VPY -m playwright install chromium"
 fi
 
-echo "=== Done ==="
+# ------------------------------------------------------------------ model
+if [ "$PREFETCH_MODEL" = "1" ]; then
+    say "  downloading the model now (4.1 GB)"
+    "$VPY" - <<'PY' || warn "model prefetch failed; it will download on first run instead"
+from huggingface_hub import snapshot_download
+snapshot_download("Qwen/Qwen3-8B-MLX-4bit")
+PY
+    ok "model cached"
+fi
+
+# ------------------------------------------------------------------- done
+say ""
+say "=== Done ==="
+say ""
+
+# Drop the user straight into the environment.
+#
+# A script cannot activate a venv in the shell that launched it — it runs in
+# its own process, and its exports die with it. Telling people to remember
+# `source venv/bin/activate` afterwards is the friction, so instead we exec a
+# new shell that already has it, the way nix-shell does. The user's original
+# shell is untouched: this replaces the installer's own process, so typing
+# `exit` returns them exactly where they started.
+#
+# Only with a terminal on both ends. In CI or a pipe there is nobody to land
+# in a shell, and exec'ing one there would hang the job.
+if [ "$ENTER_SHELL" = "1" ] && [ -t 0 ] && [ -t 1 ]; then
+    say "Entering the Symbio environment. ${DIM}Type 'exit' to leave.${OFF}"
+    say ""
+    say "    ${GRN}symbio${OFF}    start it ${DIM}(first run: setup wizard, then a 4.1 GB"
+    say "              model download and ~25s of cache warming; later"
+    say "              starts are about a second)${OFF}"
+    say ""
+
+    # What bin/activate does, minus the prompt rewriting, which differs per
+    # shell and is not ours to mangle.
+    VIRTUAL_ENV="$VENV"; export VIRTUAL_ENV
+    PATH="$VENV/bin:$PATH"; export PATH
+    unset PYTHONHOME 2>/dev/null || true
+    export SYMBIO_ENV=1
+
+    exec "${SHELL:-/bin/zsh}"
+fi
+
+say "Start it with:"
+say ""
+say "    $VENV/bin/symbio"
+say ""
+say "  ${DIM}First launch runs the setup wizard, then downloads the model (4.1 GB)"
+say "  and spends ~25s warming its cache. Later starts are about a second.${OFF}"
+say ""
+say "  ${DIM}Or activate the environment yourself:"
+say "      source $VENV/bin/activate${OFF}"
+say ""

--- a/patch_prompt.py
+++ b/patch_prompt.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Add worked tool-call examples to prompt.md.
+
+Measured, not guessed. Running the same cron battery twice against the same
+model — once with the real prompt, once with these three lines appended in
+memory — gave:
+
+    invoked     4/9  ->  9/9
+    cron_list   0/3  ->  3/3
+    cron_schedule 1/3 -> 3/3
+    cron_delete   3/3 -> 3/3   (control: already had an example, unchanged)
+
+The mechanism: of the 27 tools declared in the <tools> block, only two have a
+worked example anywhere in the prompt. A tool the model has seen declared but
+never seen *called* gets a call shape invented for it, and the invented shapes
+mostly do not parse — so the tool silently never runs while a success-looking
+sentence goes to the user. delete_cron_job is the one cron tool with an
+example, and the model reproduces that example character-for-character, which
+is what made the control test possible.
+
+prompt.md is gitignored — it is yours, and every install's copy differs — so
+this cannot ship as a normal commit. Hence a patcher.
+
+    python3 patch_prompt.py            # apply
+    python3 patch_prompt.py --dry-run  # show what would change
+    python3 patch_prompt.py --revert   # take them back out
+
+Safe to run twice: it detects its own marker and does nothing.
+
+AFTER APPLYING: the prompt no longer matches the corpus the adapter was
+trained on. That is a soft mismatch, not a crash, and the measurement above
+was taken with exactly that mismatch in place — so the gain is real without a
+retrain. Retraining will resync it; let the golden set gate that, as designed.
+
+DO NOT BLINDLY EXTEND THIS BLOCK.
+
+The obvious next move — an example for each of the ~25 tools that lack one —
+was tested across the whole surface, 23 cases, 138 runs. It is not safe:
+
+    completed  53/69 -> 58/69     (77% -> 84%, net +5)
+
+    improved:  config_show 0/3->3/3, cron_list 0/3->3/3, cron_schedule 2/3->3/3,
+               add_golden_case 2/3->3/3, read_page 2/3->3/3, digest_notes 1/3->2/3
+    REGRESSED: save_memory 3/3->0/3, execute_code 1/3->0/3, compact_memory 3/3->2/3
+
+An example helps a tool the model cannot reach, and can break a neighbouring
+tool it was already reaching, by adding a competing candidate next to it —
+save_memory worked perfectly until compact_memory was given an example beside
+it. The three lines below stay because cron-only was measured on its own and
+gained without costing anything: 4/9 -> 9/9, no regressions.
+
+So: add examples for tools the battery shows failing, one group at a time, and
+re-run tool_eval before and after. Never in bulk.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+PROMPT = ROOT / "prompt.md"
+
+MARKER = "<!-- tool-call examples added by patch_prompt.py -->"
+
+ANCHOR = "- Correct cron edit example:"
+
+BLOCK = f"""{MARKER}
+- Correct reminder example: <tool_call>{{{{"name": "schedule_job", "arguments": {{{{"schedule": "0 9 * * *", "text": "stand up and stretch"}}}}}}}}</tool_call>
+- Correct example for listing reminders: <tool_call>{{{{"name": "list_cron_jobs", "arguments": {{{{}}}}}}}}</tool_call>
+- Never answer from memory about what is scheduled. Call list_cron_jobs and read the result.
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--revert", action="store_true")
+    args = ap.parse_args()
+
+    if not PROMPT.exists():
+        print(f"No {PROMPT}. Start Symbio once to seed it, then re-run.")
+        return 1
+
+    text = PROMPT.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+
+    if args.revert:
+        if MARKER not in text:
+            print("Not applied; nothing to revert.")
+            return 0
+        start = next(i for i, ln in enumerate(lines) if MARKER in ln)
+        end = start + len(BLOCK.rstrip("\n").split("\n"))
+        new = "".join(lines[:start] + lines[end:])
+        return _write(new, args.dry_run, "Removed")
+
+    if MARKER in text:
+        print("Already applied. Nothing to do.")
+        return 0
+
+    idx = next((i for i, ln in enumerate(lines) if ln.startswith(ANCHOR)), None)
+    if idx is None:
+        # Anchor missing means a customised prompt. Refuse rather than guess a
+        # position — a tool example in the wrong section is worse than none,
+        # and this file is the user's own writing.
+        print(f"Could not find the anchor line in {PROMPT}:\n    {ANCHOR}\n"
+              "Your prompt.md has been customised. Add these three lines by "
+              "hand, next to the other tool guidance:\n")
+        print(BLOCK)
+        return 1
+
+    new = "".join(lines[:idx + 1] + [BLOCK] + lines[idx + 1:])
+    return _write(new, args.dry_run, "Added")
+
+
+def _write(new: str, dry_run: bool, verb: str) -> int:
+    if dry_run:
+        print(f"[dry run] would have {verb.lower()} the block. {len(new)} chars after.")
+        return 0
+    backup = PROMPT.with_suffix(f".md.bak.{datetime.now():%Y%m%d_%H%M%S}")
+    shutil.copy2(PROMPT, backup)
+    PROMPT.write_text(new, encoding="utf-8")
+    print(f"{verb} the tool-call examples in {PROMPT}")
+    print(f"Backup: {backup}")
+    print("\nRestart Symbio to pick it up. The first start will be slower — the "
+          "prompt changed, so the KV cache is rebuilt once.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/symbio/app/chat.py
+++ b/symbio/app/chat.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import re
+import shlex
 import sys
 import threading
 import time
@@ -42,6 +43,48 @@ try:
     from tag_rag import TagIndex
 except ModuleNotFoundError:  # pragma: no cover - depends on how it was launched
     TagIndex = None
+
+
+# Bare words the model reaches for when it means "launch this desktop app".
+# Only the ones actually seen failing, plus their obvious spellings — a wide
+# net here would turn a genuine "command not found" into a surprise app launch.
+_GUI_APP_ALIASES: dict[str, str] = {
+    "chrome": "Google Chrome",
+    "chromebrowser": "Google Chrome",
+    "chrome-app": "Google Chrome",
+    "chrome_app": "Google Chrome",
+    "googlechrome": "Google Chrome",
+    "google-chrome": "Google Chrome",
+    "safari": "Safari",
+    "spotify": "Spotify",
+    "finder": "Finder",
+    "terminal.app": "Terminal",
+    "notes": "Notes",
+    "calendar": "Calendar",
+    "messages": "Messages",
+    "mail": "Mail",
+    "preview": "Preview",
+    "vscode": "Visual Studio Code",
+    "code-app": "Visual Studio Code",
+}
+
+
+def _gui_app_for(cmd: str, output: str) -> str | None:
+    """The macOS app a failed bare command was probably trying to launch.
+
+    Returns None unless the command is a single bare word (no arguments, no
+    shell syntax) that names a known GUI app AND the failure was specifically
+    "command not found". A command that failed for any other reason is a real
+    failure and must be reported as one.
+    """
+    if sys.platform != "darwin":
+        return None
+    if "command not found" not in output.lower():
+        return None
+    word = cmd.strip().strip("'\"")
+    if not word or len(word.split()) != 1:
+        return None
+    return _GUI_APP_ALIASES.get(word.lower())
 
 
 def _looks_like_shell_command(cmd: str) -> bool:
@@ -762,6 +805,21 @@ class ChatSession:
         # joins it before any generation (so the model is never used by two
         # threads at once).
         self._prefill_thread: threading.Thread | None = None
+        # A persisted prompt cache is a few hundred MB of safetensors, and
+        # reading it used to start only once load() had finished — so the two
+        # slowest parts of boot ran back to back when they have nothing to say
+        # to each other. The read is pure file I/O and the weight load is
+        # mostly decompress-and-place, so the read is started *before* load()
+        # and overlaps it; by the time the model is resident the bytes are
+        # already in the page cache. See _start_prompt_cache_prefetch.
+        self._prefetch_thread: threading.Thread | None = None
+        # (cache, metadata) once the prefetch has read the file, or None. The
+        # cache is deliberately left unevaluated here: materializing it would
+        # allocate GPU buffers on a second thread while load() is allocating
+        # its own, and this codebase has a standing kernel-panic problem with
+        # concurrent Metal clients. mx.eval stays on the prefill thread, which
+        # only runs after load() has returned.
+        self._prefetched_cache: tuple[list, dict] | None = None
         self.enabled_groups: set[str] = set(
             config.get("tools", {}).get("enabled_groups", [])
         )
@@ -924,6 +982,10 @@ class ChatSession:
         # Whatever the KV cache holds refers to weights we are about to drop.
         self._prompt_cache = None
         self._cached_prompt_ids = None
+        # A prefetch that nobody consumed is a few hundred megabytes with no
+        # reader, which is the opposite of what it was added for. Dropping the
+        # weights is the point at which it can no longer be claimed.
+        self._take_prefetched_cache()
         if getattr(self, "model", None) is not None:
             del self.model
         self.model = None
@@ -946,6 +1008,14 @@ class ChatSession:
             )
             self.adapter_loaded = True
             training.mark_adapter_used()
+            # Same cold-cache problem as _wake_headmaster: _unload_model above
+            # dropped the KV cache, and without this the first turn after a
+            # retrain re-processes the whole prefix. No prefetch here, though —
+            # training rewrote the adapter, so the persisted cache's signature
+            # cannot match and reading it would be pure waste. This prefill is
+            # a real one, which is exactly why it belongs on a background
+            # thread rather than in front of the user's next message.
+            self._prefill_system_prompt_cache(show_spinner=False)
             return None
         except Exception as e:
             # We already dropped the previous model, so returning here would
@@ -971,10 +1041,25 @@ class ChatSession:
         self._status("  [Dispatch] Headmaster asleep.")
 
     def _wake_headmaster(self):
-        """Reload the headmaster model after a worker finishes."""
+        """Reload the headmaster model after a worker finishes, warm.
+
+        Waking used to hand back a model with a cold KV cache. _unload_model
+        drops _prompt_cache along with the weights — it has to, the cached
+        values belong to weights that no longer exist — and nothing rebuilt it,
+        so the turn after every delegation silently re-processed the whole
+        ~4000-token system+tools prefix through the model. The delegation saved
+        RAM and spent that saving on latency the user paid at the worst moment:
+        immediately after waiting for a worker.
+
+        So the wake mirrors the boot path. The cache read starts before load()
+        and overlaps it, and the prefill runs afterwards — which, since the
+        model, adapter and prompt are all unchanged since boot, is a signature
+        hit on the persisted file rather than a real prefill.
+        """
         if getattr(self, "model", None) is not None:
             return
         self._status("  [Dispatch] Headmaster waking up (reloading 8B model)...")
+        self._start_prompt_cache_prefetch()
         try:
             if self.adapter_config.exists():
                 self.model, self.tokenizer = load(
@@ -985,6 +1070,7 @@ class ChatSession:
                 self.model, self.tokenizer = load(self.config["model_name"])
                 self.adapter_loaded = False
             training.mark_adapter_used()
+            self._prefill_system_prompt_cache(show_spinner=False)
             self._status("  [Dispatch] Headmaster awake.")
         except Exception as e:
             self._status(f"  [Dispatch] Headmaster reload failed: {e}")
@@ -1013,6 +1099,16 @@ class ChatSession:
             # Cap MLX's buffer cache before the first allocation, so a long
             # chat session doesn't sit on GPU memory a training run needs.
             apply_gpu_limits(self.config)
+
+            # Start reading the persisted KV cache off disk now, so those
+            # hundreds of megabytes stream in while load() is busy with the
+            # weights instead of after it. Pure I/O on a daemon thread; it
+            # touches neither the model nor the GPU. Started before the
+            # "Waking model..." line so a slow first read still overlaps the
+            # whole load, and deliberately inside the try below's scope so a
+            # load failure still leaves it harmless (it is only ever consumed
+            # by the prefill, which does not run if the load failed).
+            self._start_prompt_cache_prefetch()
 
             # Don't spin during load(): HuggingFace's download progress bar
             # animates the same terminal line via \r, and the two carriages
@@ -1266,16 +1362,46 @@ class ChatSession:
                 # which the next run's prefix diff could not reuse.
                 if self.config.get("agent", {}).get("persist_prompt_cache", True):
                     self._save_persisted_prompt_cache(system_ids)
-            except Exception:
+            except Exception as e:
                 # Prefill is an optimization, never a hard requirement. Clear any
                 # partial state so the next generation rebuilds cleanly.
+                #
+                # But say why. Swallowing this silently is how the prefill came
+                # to be dead in the running app while every switch that controls
+                # it read as enabled: no cache file was ever written, every turn
+                # reported "cached 0", and nothing anywhere said a word. The
+                # save path next to this one already logs its failures; this one
+                # not doing so hid a broken feature rather than a slow one.
+                self._log_info(f"Prompt cache prefill failed: {e!r}")
                 self._prompt_cache = None
                 self._cached_prompt_ids = None
             finally:
                 self._indexing_now = False
 
-        self._prefill_thread = threading.Thread(target=_prefill, daemon=True)
-        self._prefill_thread.start()
+        # Run it here, on the calling thread, NOT on a background one.
+        #
+        # This used to start a daemon thread so the user could type their first
+        # message while the ~5k-token prefix warmed. That never once worked.
+        # generate_step calls mx.eval on the cache state, MLX's stream registry
+        # is thread-local, and evaluating a cache built from main-thread model
+        # weights on another thread raises
+        #     RuntimeError: There is no Stream(cpu, N) in current thread.
+        # after zero yields, on every boot, with this MLX build. The bare
+        # except below swallowed it in silence, so the feature reported as
+        # enabled while never having run: no cache file was ever written and
+        # every turn logged "cached 0".
+        #
+        # Entering the main thread's stream inside the worker does not fix it —
+        # tried, still raises — because the failing stream is a cpu one owned by
+        # the arrays, not the device stream the worker enters.
+        #
+        # So this now blocks. It costs ~24s on a first boot, once: the whole
+        # point of persisting the cache is that every later boot loads the file
+        # instead of prefilling, and _start_prompt_cache_prefetch overlaps even
+        # that read with the model load. Paying 24s once to make the feature
+        # real beats an unblocking optimization that never produced a cache.
+        _prefill()
+        self._prefill_thread = None
 
     def _log_info(self, message: str):
         """Log only once the session logger exists.
@@ -1315,24 +1441,91 @@ class ChatSession:
             "n_tokens": str(len(system_ids)),
         }
 
+    def _start_prompt_cache_prefetch(self):
+        """Begin reading the persisted KV cache while the weights are loading.
+
+        The two slowest things at boot are the weight load and the prompt-cache
+        read, and they were strictly sequential: the read only began once
+        _finish_model_setup started the prefill, which is after load() returns.
+        They contend for almost nothing — one is file I/O, the other is mostly
+        CPU placing tensors — so running the read underneath the load hides it
+        almost entirely, and the first turn is warm the moment the model is.
+
+        What this thread must NOT do is touch the GPU. Materializing the cache
+        here would put a second Metal client in the same window as the weight
+        load, which is the shape that panics IOGPUFamily on this hardware. So
+        it stops at the read: load_prompt_cache leaves the arrays lazy, and the
+        mx.eval that actually allocates stays on the prefill thread, after the
+        load has finished. The signature check needs a tokenizer that does not
+        exist yet, so it also waits — a mismatched file costs one wasted read,
+        which is exactly what it cost before.
+        """
+        if not self.config.get("agent", {}).get("prompt_cache_enabled", True):
+            return
+        if not self.config.get("agent", {}).get("persist_prompt_cache", True):
+            return
+        if not self.config.get("agent", {}).get(
+                "prefetch_prompt_cache_during_load", True):
+            return
+        path = constants.PROMPT_CACHE_FILE
+        if not path.exists():
+            return
+
+        def _prefetch():
+            try:
+                cache, meta = load_prompt_cache(str(path), return_metadata=True)
+                self._prefetched_cache = (cache, meta)
+            except Exception:
+                # Nothing is owed here. A failure leaves _prefetched_cache None
+                # and _load_persisted_prompt_cache reads the file itself, which
+                # is what it did before this existed — including the unlink of
+                # a truncated file, so the error is still handled, just later.
+                self._prefetched_cache = None
+
+        self._prefetch_thread = threading.Thread(target=_prefetch, daemon=True)
+        self._prefetch_thread.start()
+
+    def _take_prefetched_cache(self) -> tuple[list, dict] | None:
+        """Hand over the prefetched (cache, metadata), waiting for it if needed.
+
+        Consumed exactly once: a KV cache is mutated in place by generation, so
+        handing the same object to a second caller would give two readers one
+        buffer. After this returns the prefetch is spent and a later miss falls
+        back to reading the file.
+        """
+        thread = self._prefetch_thread
+        if thread is not None:
+            thread.join()
+            self._prefetch_thread = None
+        taken = self._prefetched_cache
+        self._prefetched_cache = None
+        return taken
+
     def _load_persisted_prompt_cache(self, system_ids: list[int]) -> bool:
         """Restore the warmed system-prefix cache from disk.
 
         Returns True if the cache was loaded and is safe to use. Reading a few
         hundred MB off an SSD is roughly an order of magnitude cheaper than
-        re-running the prefill through the model, which is the whole point.
+        re-running the prefill through the model, which is the whole point —
+        and cheaper still when _start_prompt_cache_prefetch already read it
+        underneath the weight load, in which case there is nothing left to wait
+        for here.
         """
         path = constants.PROMPT_CACHE_FILE
         if not path.exists():
             return False
         want = self._prompt_cache_signature(system_ids)
-        try:
-            cache, meta = load_prompt_cache(str(path), return_metadata=True)
-        except Exception as e:
-            # A truncated or version-mismatched file is not worth keeping.
-            self._log_info(f"Prompt cache unreadable, discarding: {e}")
-            path.unlink(missing_ok=True)
-            return False
+        prefetched = self._take_prefetched_cache()
+        if prefetched is not None:
+            cache, meta = prefetched
+        else:
+            try:
+                cache, meta = load_prompt_cache(str(path), return_metadata=True)
+            except Exception as e:
+                # A truncated or version-mismatched file is not worth keeping.
+                self._log_info(f"Prompt cache unreadable, discarding: {e}")
+                path.unlink(missing_ok=True)
+                return False
         if any(meta.get(k) != v for k, v in want.items()):
             # The model, adapter or prompt changed since it was written.
             path.unlink(missing_ok=True)
@@ -1826,8 +2019,16 @@ class ChatSession:
         the freshly trained adapter anyway. On a skipped run, a failure, or
         an exception, the previous model is restored before returning.
         """
+        # Both branches end the same way: a trainer child process has exited,
+        # and whoever called this reloads the adapter immediately afterwards.
+        # That reload is a multi-gigabyte allocation landing in the middle of
+        # the child's bulk Metal teardown, which is the sequence that panics
+        # the driver — so the wait goes here, once, rather than at each of the
+        # several places that reload.
         if not self.config.get("gpu", {}).get("unload_model_during_training", True):
-            return training.run_training(self.config, iters=iters)
+            trained = training.run_training(self.config, iters=iters)
+            training.settle_after_trainer_exit(self.config, status_fn=self.output_fn)
+            return trained
 
         self.output_fn("  [Train] Unloading model so the trainer has the GPU to itself...")
         self._unload_model()
@@ -1836,6 +2037,7 @@ class ChatSession:
             trained = training.run_training(self.config, iters=iters)
             return trained
         finally:
+            training.settle_after_trainer_exit(self.config, status_fn=self.output_fn)
             if not trained:
                 self._restore_model()
 
@@ -2653,6 +2855,18 @@ class ChatSession:
             from symbio.app.config import save_config
             rest = user_input[len("/telemetry"):].strip().lower()
             tcfg = self.config.setdefault("telemetry", {})
+            # `/telemetry` with no argument, or `/telemetry activity [days]`,
+            # reads the local activity log back. It had been written to since
+            # day one and never once read — log_path() existed and nothing
+            # called it — so a MEDIUM-risk security alert and a tool failing
+            # four calls in five both sat in the file unnoticed.
+            if rest in ("", "all") or rest.split()[0] in ("activity", "all"):
+                parts = rest.split()
+                verbose = "all" in parts
+                days = next((int(p) for p in parts if p.isdigit()), None)
+                report = local_telemetry.summarise(days=days)
+                self.output_fn(local_telemetry.format_summary(report, verbose=verbose))
+                return True
             if rest in ("on", "enable", "true", "yes", "1"):
                 # Re-ask consent with the full data set disclosed, honoring the
                 # "required consent" rule: the user can say No and keep going.
@@ -3264,9 +3478,21 @@ class ChatSession:
             browser_note = ""
             if self.browser.is_open:
                 browser_note = "\n\n[" + self.browser.status() + "]"
+            # Static parts first, volatile parts last.
+            #
+            # This block is prepended to the last user message, so everything
+            # from the first byte that differs from last turn has to be
+            # re-prefilled. env_note is fixed for the life of the machine;
+            # sitting it after rag_block meant a new retrieval hit pushed it
+            # into the re-prefilled region every time, for nothing.
+            #
+            # Measured on a 349-token block: when the clock ticks alone this
+            # changes nothing (344 tokens reused either way), but when the RAG
+            # hit also changes — the common case, since retrieval runs per
+            # query — reuse goes from 141 tokens to 243.
             context_block = (
-                memory.curated_memory_block(self.config) + rag_block
-                + prompts.env_note() + prompts.time_note() + nudge_block
+                memory.curated_memory_block(self.config) + prompts.env_note()
+                + rag_block + prompts.time_note() + nudge_block
                 + browser_note
             ).lstrip()
             # Greeting guard: the small model sometimes invents random tool
@@ -4049,6 +4275,67 @@ class ChatSession:
                 ok, out = sandbox.run_shell(cmd, self.config, confirm_fn=self.confirm_fn)
                 return f"Shell command exited {'ok' if ok else 'error'}.\nOutput:\n{out}"
             ok, out = sandbox.run_sandboxed(params["cmd"], self.config, confirm_fn=self.confirm_fn)
+
+            # Launch a GUI app the way macOS actually launches one.
+            #
+            # 481 of the 542 run_command failures in the activity log are this
+            # single mistake: the model trying to start a desktop app by a CLI
+            # name that has never existed.
+            #
+            #     241  chrome            120  chromebrowser
+            #     120  chrome-app
+            #
+            # env_note() already tells it, in the prompt, on every single turn,
+            # that "GUI apps have no CLI names like 'chrome'" and to use
+            # `open -a 'Google Chrome'`. It read that and did it anyway, 481
+            # times. Another sentence of prompt is not the fix; this is
+            # deterministic and belongs in code.
+            if not ok:
+                app = _gui_app_for(params["cmd"], out)
+                if app:
+                    self._status(f"  [Shell] '{params['cmd'].strip()}' is a GUI app; "
+                                 f"launching it with open -a '{app}'.")
+                    retry = f"open -a {shlex.quote(app)}"
+                    ok, out = sandbox.run_sandboxed(
+                        retry, self.config, confirm_fn=self.confirm_fn)
+                    local_telemetry.log_event(
+                        "gui_launch_recover", asked=params["cmd"].strip(),
+                        app=app, ok=ok)
+
+                    # Recover the action AND keep the lesson.
+                    #
+                    # This turn's failure-then-fix is normally what feeds the
+                    # mistake-note loop: a tool call that fails followed by one
+                    # that works gets captured, digested, and trained on. By
+                    # recovering internally the loop would never see a failure,
+                    # and the model would go on emitting `chrome` forever with
+                    # nothing to learn from.
+                    #
+                    # Writing the note here keeps that signal. Worth noting the
+                    # loop had this exact lesson available 481 times already and
+                    # the mistake kept happening — so this is not a substitute
+                    # for the deterministic fix above, it is the training data
+                    # the fix would otherwise have destroyed.
+                    if ok:
+                        try:
+                            learn.save_mistake_note(
+                                original_query=f"launch the {app} app",
+                                wrong_answer=f"<cmd>{params['cmd'].strip()}</cmd>",
+                                # Carry the real failure text, not a paraphrase.
+                                # The note is training data, and the model
+                                # needs to see the error it actually produced.
+                                correction=(
+                                    f"Command not found: {params['cmd'].strip()}. "
+                                    f"GUI apps have no CLI name; launch them "
+                                    f"with open -a."),
+                                correct_answer=f"<cmd>{retry}</cmd>",
+                            )
+                        except Exception:
+                            # Never let bookkeeping fail a turn that worked.
+                            pass
+
+                    return (f"Command '{retry}' exited {'ok' if ok else 'error'}.\n"
+                            f"Output:\n{out}")
             return f"Command '{params['cmd']}' exited {'ok' if ok else 'error'}.\nOutput:\n{out}"
 
         if name == "run_remote":
@@ -4140,7 +4427,63 @@ class ChatSession:
                     "Retry now with <press>down</press>. "
                     "Do not explain the failure — just emit the corrected press tag."
                 )
-            out = browser_action_tools[name]()
+            def _act() -> str:
+                """Run the action, turning a raised 'not open' into the same
+                string the other paths return.
+
+                The browser reports a closed session two different ways and the
+                activity log shows both: 314 failures came back as a returned
+                "Browser click error: Browser is not open...", and another 122
+                as "Tool 'browser_click' failed unexpectedly: Browser is not
+                open..." — an exception caught by the generic handler upstream.
+                Recovering only the returned form would leave more than a
+                quarter of the failures untouched for no reason.
+                """
+                try:
+                    return browser_action_tools[name]()
+                except Exception as exc:
+                    if "browser is not open" in str(exc).lower():
+                        # name already reads "browser_click"; prefixing another
+                        # "Browser" gives "Browser browser_click error".
+                        return f"{name} error: {exc}"
+                    raise
+
+            out = _act()
+
+            # Reopen and retry once when the page is gone.
+            #
+            # This is the single largest tool failure in the system. Of 567
+            # browser_click calls in the local activity log, 453 failed, and
+            # 450 of those failed with "Browser is not open" — the model
+            # clicking at a page that was never opened or whose session was
+            # reset. The old behaviour was to append a sentence telling it to
+            # open a page first, which it had already been told and which
+            # plainly was not working.
+            #
+            # _last_browsed_url has existed since the beginning for exactly
+            # this, described in its own comment as being "used to auto-recover
+            # when a later click/type/scroll/press finds the browser session
+            # was reset or never opened". It was assigned and never once read.
+            #
+            # Recovery is only attempted for a real action (closing a browser
+            # by reopening it first is absurd), only when there is a URL this
+            # session already opened successfully, and only once — a retry loop
+            # against a page that will not load is worse than a clear failure.
+            if (
+                "Browser is not open" in out
+                and name != "browser_close"
+                and self._last_browsed_url
+            ):
+                self._status(f"  [Browser] Session was closed; reopening "
+                             f"{self._last_browsed_url} to retry {name}.")
+                reopened = self.browser.open(self._last_browsed_url)
+                if "blocked" not in reopened and "error" not in reopened.lower():
+                    out = _act()
+                    local_telemetry.log_event(
+                        "browser_recover", url=self._last_browsed_url, tool=name,
+                        ok="Browser is not open" not in out,
+                    )
+
             if "Browser is not open" in out:
                 out = (
                     f"{out} Use <browse>https://...</browse> to load a page first, "

--- a/symbio/app/config.py
+++ b/symbio/app/config.py
@@ -39,6 +39,22 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "iters": 300,
         "epochs": 2,
         "max_iters": 2000,
+        # How long to wait after a trainer child exits before loading a model
+        # again. The child hands every Metal buffer back in one bulk teardown,
+        # and a multi-gigabyte allocation landing in the middle of that is what
+        # panics IOGPUFamily on Apple silicon — three kernel panics in twenty
+        # minutes on 2026-08-17. vm_stat reports the pages free immediately,
+        # so this floor covers the driver-side reclaim that cannot be observed
+        # from userspace; settle_free_gb then polls for the part that can.
+        # Set to 0 to disable (there is no userspace fix, only less exposure).
+        "settle_after_training_seconds": 15,
+        "settle_free_gb": 6.0,
+        "settle_timeout_seconds": 180,
+        # Ceiling on how many passes the `iters` floor may buy a small corpus.
+        # Without it the floor stops being a floor: at 6 samples the old 150
+        # meant 25 epochs, which memorises the samples instead of learning
+        # from them.
+        "max_epochs": 4,
         # Compute the loss only over the assistant's answer. Without this the
         # system prompt — ~99% of every sample's tokens, and identical across
         # all of them — dominates the gradient, and the run measures how well
@@ -93,6 +109,15 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # model. Costs a few hundred MB in cache/ (KV for the whole prefix);
         # set false to trade the faster start back for the disk.
         "persist_prompt_cache": True,
+        # Start reading that persisted cache off disk *while* the weights are
+        # still loading, rather than after. The two are the slowest parts of
+        # boot and contend for almost nothing, so overlapping them hides the
+        # read almost entirely. Only the read is overlapped — the cache is not
+        # materialized onto the GPU until the weight load has finished, so
+        # there is never a second Metal client during the load window.
+        # Set false on a memory-tight machine: the read raises peak page-cache
+        # residency at the moment the load is already at its high-water mark.
+        "prefetch_prompt_cache_during_load": True,
         # How long a chat front-end should wait before showing a "thinking…"
         # placeholder if the model has not emitted a visible token yet.
         "first_chunk_timeout_ms": 600,
@@ -305,7 +330,15 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "max_worker_rounds": 4,
         "worker_golden_set_enabled": True,
         "worker_golden_regression_threshold": 0,
+        # Applies to hand-written eval_tasks.json only. Derived checks grade a
+        # reply by how much of the steps text it reproduces, so a worker that
+        # learns to perform its skill fails them by definition; those report
+        # without reverting (see skill_eval.has_custom_tasks).
         "worker_golden_rollback_on_regression": True,
+        # Append each worker reply to that worker's training corpus. Off by
+        # default: nothing validates the reply first, so this trains a worker
+        # on its own unchecked output.
+        "capture_worker_samples": False,
         # When a worker adapter regresses on a golden case, synthesize extra
         # training samples from the case's ideal reply and do a targeted
         # retrain before deciding whether to roll back.

--- a/symbio/app/dispatch.py
+++ b/symbio/app/dispatch.py
@@ -27,13 +27,34 @@ from symbio import constants
 from symbio.app import golden, pending, tooling, training
 
 
+# (path, mtime_ns, size) -> parsed catalog. The file is small, but it is read
+# on a path that runs several times per delegated turn — once per resident
+# donor inside _try_hot_swap, and again for every entry lookup — so re-parsing
+# it each time is work done repeatedly to reach the same answer. Keyed on the
+# stat rather than a TTL because the thing that invalidates it is a skill being
+# saved or deleted, which rewrites the file; a stale read there would route a
+# turn to a worker that no longer exists.
+_CATALOG_CACHE: tuple[Any, ...] | None = None
+
+
 def load_catalog() -> dict[str, dict[str, Any]]:
-    if not constants.WORKER_MODELS_FILE.exists():
-        return {}
+    global _CATALOG_CACHE
+    path = constants.WORKER_MODELS_FILE
     try:
-        return json.loads(constants.WORKER_MODELS_FILE.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        st = path.stat()
+    except OSError:
+        _CATALOG_CACHE = None
         return {}
+    key = (str(path), st.st_mtime_ns, st.st_size)
+    if _CATALOG_CACHE is not None and _CATALOG_CACHE[0] == key:
+        return _CATALOG_CACHE[1]
+    try:
+        catalog = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        _CATALOG_CACHE = None
+        return {}
+    _CATALOG_CACHE = (key, catalog)
+    return catalog
 
 
 def catalog_entry_for_role(role: str) -> dict[str, Any] | None:
@@ -305,6 +326,12 @@ class WorkerPool:
         if role in self._resident:
             model, tokenizer, _ = self._resident[role]
             self._resident[role] = (model, tokenizer, time.time())
+            # Every path out of get() marks the adapter used, including this
+            # one. It is the path a busy worker takes — the second and every
+            # later delegation in a row — and leaving it out meant the more a
+            # worker was used, the staler its last-used stamp looked, which is
+            # what archive_idle_items reads to decide it can be archived.
+            training.mark_adapter_used(role=role)
             return model, tokenizer, (catalog_entry_for_role(role) or {})
 
         entry = catalog_entry_for_role(role)
@@ -424,6 +451,37 @@ class WorkerPool:
             return model, tokenizer, entry
         return None
 
+    def _run_worker(self, model, tokenizer, system_prompt: str, user_text: str,
+                    max_tokens: int) -> str:
+        """Render one worker turn and return its reply, reasoning stripped.
+
+        Both delegation paths need exactly this, and having it written twice is
+        how they drifted: the browser loop was generating without stripping,
+        which matters more there than anywhere else, because its reply is
+        matched with startswith() against 'click:'/'type:'/'scroll'/'done'. A
+        model that opens with a think block does not fail a check — it fails
+        *every* check, and the loop reports an unrecognized action and stops.
+
+        enable_thinking is False for the same reason in both: a worker's reply
+        is an observation for the headmaster and a training sample for its own
+        adapter, and deliberation is noise in both. The headmaster is where
+        THINKING_ENABLED belongs. Measured on Qwen3.5-4B: a one-line summary
+        came back as 156 words of "Thinking Process:" with this True, and 13
+        correct words with it False — and not strippable either, because that
+        model reasons in prose rather than <think>. The strip below is for the
+        models that do use the tag.
+        """
+        prompt = tokenizer.apply_chat_template(
+            [{"role": "system", "content": system_prompt},
+             {"role": "user", "content": user_text}],
+            tokenize=False, add_generation_prompt=True, enable_thinking=False,
+        )
+        return tooling.strip_reasoning_block(generate(
+            model, tokenizer, prompt=prompt,
+            sampler=make_sampler(temp=0.2, top_p=0.9),
+            max_tokens=max_tokens, verbose=False,
+        )).strip()
+
     def _worker_system_prompt(self, role: str, entry: dict[str, Any]) -> str:
         """Return the system prompt for a worker role.
 
@@ -446,9 +504,15 @@ class WorkerPool:
         every other role is a single-shot generation. Both record their
         (input, output) pairs as training samples for that worker, so real
         usage accumulates the corpus guarded_train_worker draws on."""
-        if role == "browser" and browser is not None:
-            max_rounds = int(self._dispatch_cfg().get("max_worker_rounds", 4))
-            return self._run_browser_delegation(task, browser, max_rounds)
+        # Resolve the role before anything is unloaded for it. The headmaster
+        # used to be put to sleep first and the catalog consulted second, so a
+        # task delegated to a role that does not exist — a typo, or a skill
+        # deleted since the model last saw the list — unloaded the 8B, found
+        # nothing to run, and reloaded it. A full model reload as the price of
+        # a misspelling, for a turn that returns an error string either way.
+        if catalog_entry_for_role(role) is None:
+            known = sorted({e.get("role") for e in load_catalog().values() if e.get("role")})
+            return f"No worker configured for role '{role}'. Known roles: {', '.join(known) or 'none'}."
 
         deep_sleep = bool(self._dispatch_cfg().get("headmaster_deep_sleep_while_workers", False))
         if deep_sleep and self.before_worker_fn is not None:
@@ -456,6 +520,18 @@ class WorkerPool:
             self.before_worker_fn()
 
         try:
+            # Inside the bracket, not before it. The browser loop used to
+            # return above all of this, so with deep sleep on it loaded its
+            # worker while the headmaster was still resident — the two-models-
+            # at-once state the whole setting exists to prevent, reached by the
+            # one role that holds its worker for several rounds. Nothing
+            # refused it either: _second_headmaster_copy_refusal stands down
+            # when deep sleep is configured, on the assumption that the sleep
+            # actually happened.
+            if role == "browser" and browser is not None:
+                max_rounds = int(self._dispatch_cfg().get("max_worker_rounds", 4))
+                return self._run_browser_delegation(task, browser, max_rounds)
+
             try:
                 loaded = self.get(role)
             except SecondHeadmasterCopyRefused as exc:
@@ -465,45 +541,28 @@ class WorkerPool:
                 known = sorted({e.get("role") for e in load_catalog().values() if e.get("role")})
                 return f"No worker configured for role '{role}'. Known roles: {', '.join(known) or 'none'}."
             model, tokenizer, entry = loaded
-            training.mark_adapter_used(role=role)
+            # get() already marked it; a second call here does the same write
+            # twice per delegation for no reader.
             self._status(f"  [Dispatch] Delegating to '{role}': {task[:80]}{'...' if len(task) > 80 else ''}")
             system_prompt = self._worker_system_prompt(role, entry)
-            messages = [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": task},
-            ]
-            prompt = tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True,
-                # Workers do not reason out loud. Their reply is an
-                # observation for the headmaster and a training sample
-                # for their own adapter, and reasoning is noise in both.
-                # The headmaster is where THINKING_ENABLED belongs.
-                # Measured on Qwen3.5-4B: a one-line summary came back
-                # as 156 words of "Thinking Process:" with this True,
-                # and 13 correct words with it False. Not strippable
-                # either — that model reasons in prose, not <think>.
-                enable_thinking=False,
-            )
             try:
-                # A worker's reply is used twice: as the observation handed
-                # back to the headmaster, and as a training sample for this
-                # worker's own adapter. A reasoning block has no business in
-                # either — it is working-out, not an answer, and training on
-                # it teaches the worker to reply with its own deliberation.
-                # Observed after retargeting 'summarize' at a reasoning model:
-                # a one-line summary came back as 160 words opening with
-                # "Thinking Process: 1. Analyze the Request".
-                reply = tooling.strip_reasoning_block(generate(
-                    model, tokenizer, prompt=prompt,
-                    sampler=make_sampler(temp=0.2, top_p=0.9),
-                    max_tokens=max_tokens, verbose=False,
-                )).strip()
+                reply = self._run_worker(
+                    model, tokenizer, system_prompt, task, max_tokens)
             except Exception as e:
                 self._status(f"  [Dispatch] Worker '{role}' failed: {e}")
                 return f"Worker '{role}' failed: {e}"
 
             self._status(f"  [Dispatch] Worker '{role}' returned {len(reply.split())} word(s).")
-            if reply:
+            # Opt-in, and off by default: this writes the worker's own output
+            # back into the corpus it will next be trained on, with nothing
+            # having checked the output first. Observed: a worker whose corpus
+            # demonstrated vegetarian-only suggestions answered a held-out
+            # prompt with lobster, and that answer was appended as a training
+            # sample — so the next retrain would have learned the violation as
+            # correct. A model graded only by itself drifts toward whatever it
+            # already does, which is the one failure a corpus cannot recover
+            # from on its own.
+            if reply and self._dispatch_cfg().get("capture_worker_samples", False):
                 training.append_chat_pair(task, reply, tokenizer, system_prompt, role=role)
             return label_worker_reply(role, reply)
         finally:
@@ -530,7 +589,6 @@ class WorkerPool:
         if loaded is None:
             return "No worker configured for role 'browser'."
         model, tokenizer, entry = loaded
-        training.mark_adapter_used(role="browser")
         system_prompt = ROLE_SYSTEM_PROMPTS["browser"]
 
         try:
@@ -543,28 +601,9 @@ class WorkerPool:
         for _ in range(max_rounds):
             status_note = f"Result of your last action: {last_status}\n\n" if last_status else ""
             prompt_text = f"Goal: {task}\n\n{status_note}Page text:\n{page_text[:1500]}"
-            messages = [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": prompt_text},
-            ]
-            prompt = tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True,
-                # Workers do not reason out loud. Their reply is an
-                # observation for the headmaster and a training sample
-                # for their own adapter, and reasoning is noise in both.
-                # The headmaster is where THINKING_ENABLED belongs.
-                # Measured on Qwen3.5-4B: a one-line summary came back
-                # as 156 words of "Thinking Process:" with this True,
-                # and 13 correct words with it False. Not strippable
-                # either — that model reasons in prose, not <think>.
-                enable_thinking=False,
-            )
             try:
-                action = generate(
-                    model, tokenizer, prompt=prompt,
-                    sampler=make_sampler(temp=0.2, top_p=0.9),
-                    max_tokens=60, verbose=False,
-                ).strip()
+                action = self._run_worker(
+                    model, tokenizer, system_prompt, prompt_text, max_tokens=60)
             except Exception as e:
                 return f"Worker 'browser' failed: {e}"
 
@@ -657,7 +696,6 @@ def _guarded_train_worker(role: str, config: dict[str, Any], iters: int | None =
     dispatch_cfg = config.get("dispatch", {})
     golden_on = dispatch_cfg.get("worker_golden_set_enabled", True)
     sampler = make_sampler(temp=0.2, top_p=0.9)
-    entry = catalog_entry_for_role(role)
 
     cases = WORKER_GOLDEN_CASES.get(role)
     skill_cases = False
@@ -772,8 +810,14 @@ def _guarded_train_worker(role: str, config: dict[str, Any], iters: int | None =
 
         # The trainer child has exited by now, but its memory only comes back
         # once the allocator reclaims it, and this is the load that would
-        # otherwise race it.
+        # otherwise race it. release_model() forces our own collection; the
+        # settle waits out the kernel's, which is the half that panics — a
+        # child exit unmaps every Metal buffer in one bulk teardown, and the
+        # load below is a multi-gigabyte allocation landing straight into it.
+        # Reading free memory *after* the wait also makes the shortfall check
+        # below judge the machine as it will be, not as it is mid-reclaim.
         training.release_model()
+        training.settle_after_trainer_exit(config)
         shortfall = training.load_memory_shortfall(
             config, entry["model_name"],
             purpose=f"reload worker '{role}' to check the new adapter")
@@ -857,7 +901,13 @@ def _guarded_train_worker(role: str, config: dict[str, Any], iters: int | None =
                     training.release_model()
                     trained2 = training.run_training(
                         config, iters=extra_iters, role=role, model_name=entry["model_name"])
+                    # Second trainer child, second bulk teardown, and the same
+                    # reload waiting on the other side of it. This is the pair
+                    # that makes one guarded_train_worker call five model loads
+                    # in a row — the densest load churn anywhere in the app,
+                    # and it runs unattended on a background thread.
                     training.release_model()
+                    training.settle_after_trainer_exit(config)
                     remedy_shortfall = training.load_memory_shortfall(
                         config, entry["model_name"],
                         purpose=f"reload worker '{role}' after remedy training")
@@ -879,11 +929,30 @@ def _guarded_train_worker(role: str, config: dict[str, Any], iters: int | None =
                     print("  [Train] No remedy samples could be generated.")
 
         if len(regressions) > threshold:
-            if backup_dir and dispatch_cfg.get("worker_golden_rollback_on_regression", True):
+            # Derived cases grade a reply on how much of the steps text it
+            # reproduces. That is the right target while the corpus is still
+            # the seeded steps-text samples -- a worker answering "I don't
+            # know." there is genuinely broken and must not ship. Once real
+            # demonstrations replace the seeds the worker is meant to stop
+            # reciting, and the same cases would revert the specialisation.
+            derived_only = (
+                skill_cases
+                and not _skill_eval.has_custom_tasks(role)
+                and not _skill_eval.corpus_teaches_recitation(
+                    role, _skill_eval.skill_steps(entry) if entry else ""))
+            rollback_on = dispatch_cfg.get(
+                "worker_golden_rollback_on_regression", True)
+            if backup_dir and rollback_on and not derived_only:
                 training.restore_adapter(backup_dir, role=role)
                 return True, (
                     f"Worker '{role}' trained but regressed on {len(regressions)} "
                     f"check(s) ({', '.join(regressions)}); rolled back.")
+            if derived_only and rollback_on:
+                return True, (
+                    f"Worker '{role}' trained; {len(regressions)} derived "
+                    f"check(s) ({', '.join(regressions)}) no longer recite the "
+                    f"steps text. Kept — derived checks report only. Add "
+                    f"{_skill_eval.tasks_path_for(role).name} to make them block.")
             return True, (
                 f"Worker '{role}' trained but regressed on {len(regressions)} "
                 f"check(s) ({', '.join(regressions)}); kept anyway.")

--- a/symbio/app/local_telemetry.py
+++ b/symbio/app/local_telemetry.py
@@ -13,8 +13,10 @@ toggles it live without a restart.
 from __future__ import annotations
 
 import json
+import re
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 from symbio import constants
@@ -70,3 +72,203 @@ def log_event(kind: str, **fields: Any) -> None:
 def log_path() -> str:
     """Return the absolute path of the telemetry .txt (for /status etc.)."""
     return str(_LOG_FILE)
+
+
+# --------------------------------------------------------------------------
+# Reading it back.
+#
+# Everything above has been writing since day one and nothing ever read a line
+# of it — log_path() was defined and called from nowhere. activity.txt reached
+# 985 KB and ~13,000 events on this machine, including a MEDIUM-risk security
+# alert for a command that arrived through prompt injection: recorded at the
+# moment it happened, and never seen, because there was no way to ask.
+#
+# A write-only log is not telemetry, it is a disk cost.
+
+_LINE_RE = re.compile(r"^\[(?P<ts>[^\]]+)\] (?P<kind>\w+)(?P<rest> .*)?$")
+_FIELD_RE = re.compile(r"(\w+)=(.*?)(?=\s+\w+=|$)")
+
+
+def _parse_line(line: str) -> dict[str, Any] | None:
+    m = _LINE_RE.match(line.rstrip("\n"))
+    if not m:
+        return None
+    out: dict[str, Any] = {"ts": m.group("ts"), "kind": m.group("kind")}
+    for k, v in _FIELD_RE.findall((m.group("rest") or "").strip()):
+        out[k] = v.strip()
+    return out
+
+
+def read_events(since: datetime | None = None,
+                path: str | None = None) -> list[dict[str, Any]]:
+    """Parse activity.txt into event dicts, oldest first."""
+    target = Path(path) if path else _LOG_FILE
+    if not target.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    with open(target, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            ev = _parse_line(line)
+            if ev is None:
+                continue
+            if since is not None:
+                try:
+                    if datetime.strptime(ev["ts"], "%Y-%m-%d %H:%M:%S") < since:
+                        continue
+                except ValueError:
+                    continue
+            events.append(ev)
+    return events
+
+
+def summarise(days: int | None = None,
+              path: str | None = None) -> dict[str, Any]:
+    """Aggregate the activity log into the questions worth asking of it.
+
+    The per-tool success rate is the one that matters. It is the same thing
+    tool_eval.py measures in a lab, measured instead against what actually
+    happened. A tool with a low rate is failing in real use; a tool that never
+    appears at all is one the model is not reaching, which is the failure that
+    leaves no other trace.
+    """
+    since = datetime.now() - timedelta(days=days) if days is not None else None
+    events = read_events(since=since, path=path)
+
+    tools: dict[str, dict[str, int]] = {}
+    alerts: list[dict[str, Any]] = []
+    blocked: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+
+    for ev in events:
+        counts[ev["kind"]] = counts.get(ev["kind"], 0) + 1
+        if ev["kind"] != "tool":
+            continue
+        result = ev.get("result", "")
+        declined = (result.startswith(("Blocked", "Refused"))
+                    or "denied" in result.lower())
+
+        slot = tools.setdefault(ev.get("name", "?"),
+                                {"calls": 0, "ok": 0, "declined": 0})
+        slot["calls"] += 1
+        if declined:
+            # The user saying no is not the tool failing.
+            #
+            # Counting refusals as failures made browser_open read as 83% ok
+            # and land in the "struggling" list. 74 of its 75 failures were
+            # "User denied access to ..." — the safety gate doing precisely its
+            # job. An instrument that reports a working gate as a broken tool
+            # sends you to fix something that is right, which is worse than
+            # reporting nothing.
+            slot["declined"] += 1
+        elif str(ev.get("ok", "")).lower() == "true":
+            slot["ok"] += 1
+
+        if "Security alert" in result:
+            alerts.append(ev)
+        if declined:
+            blocked.append(ev)
+
+    return {
+        "events": len(events),
+        "counts": counts,
+        "turns": counts.get("turn", 0),
+        "tools": dict(sorted(tools.items(),
+                             key=lambda kv: kv[1]["calls"], reverse=True)),
+        "alerts": alerts,
+        "blocked": blocked,
+        # The file actually read, not the default — reporting _LOG_FILE while
+        # summarising a different path names a file the numbers did not come
+        # from, which is worse than naming none.
+        "path": str(Path(path) if path else _LOG_FILE),
+    }
+
+
+def _pct(n: int, total: int) -> str:
+    return f"{100 * n / total:.0f}%" if total else "n/a"
+
+
+# A tool is "failing" below this rate, and only once it has been called enough
+# times for the rate to mean anything. Sample size is doing real work here:
+# at 5 calls, read_page ("1 call, 0% ok") read as the second-worst tool in the
+# system, and browser_press ("6 calls, 33%") sat above run_command's 1643.
+# Neither was a finding. 20 is where the number starts meaning something.
+_OK_THRESHOLD = 0.90
+_MIN_CALLS = 20
+
+
+def format_summary(report: dict[str, Any], verbose: bool = False) -> str:
+    """Say what is wrong. Say nothing otherwise.
+
+    The first version of this printed sixteen rows of per-tool statistics, of
+    which fifteen said 100%. That is a data dump wearing a report's clothes: it
+    makes the reader find the one line that matters, which is the job the tool
+    was supposed to do. Everything healthy is now silent, and `verbose` brings
+    the table back for when you actually want to read it.
+    """
+    if not report["events"]:
+        return "  Nothing recorded yet."
+
+    tools = report["tools"]
+    if not tools:
+        return "  No tool has ever been called. The model is not reaching them."
+
+    # Rates are over calls that actually ran. A call the user declined never
+    # reached the tool, so it can say nothing about whether the tool works.
+    def ran(t: dict[str, int]) -> int:
+        return t["calls"] - t.get("declined", 0)
+
+    total = sum(ran(t) for t in tools.values())
+    failing = [(n, t) for n, t in tools.items()
+               if ran(t) >= _MIN_CALLS and t["ok"] / ran(t) < _OK_THRESHOLD]
+    failing.sort(key=lambda nt: nt[1]["ok"] / ran(nt[1]))
+
+    lines: list[str] = []
+
+    if failing:
+        # One headline, named and in plain words. A list of four "problems" is
+        # still a triage exercise handed back to the reader; the worst tool is
+        # the thing to go fix, and the rest is a footnote until it is fixed.
+        name, t = failing[0]
+        lines.append(f"  {name} is your worst tool — "
+                     f"it {_in_words(t['ok'], ran(t))} ({ran(t)} calls).")
+        others = len(failing) - 1
+        fine = len(tools) - len(failing)
+        tail = []
+        if others:
+            tail.append(f"{others} other{'s are' if others != 1 else ' is'} struggling")
+        if fine:
+            tail.append(f"{fine} fine")
+        if tail:
+            lines.append("  " + ", ".join(tail).capitalize() + ".")
+    else:
+        lines.append(f"  All good — {total} tool calls, "
+                     f"{_pct(sum(t['ok'] for t in tools.values()), total)} ok.")
+
+    if report["alerts"]:
+        n = len(report["alerts"])
+        lines.append(f"  {n} security alert{'s' if n != 1 else ''}, "
+                     f"most recent {report['alerts'][-1]['ts']}.")
+
+    if verbose:
+        lines.append("")
+        for name, t in tools.items():
+            lines.append(
+                f"    {name:18s} {ran(t):5d} calls  "
+                f"{_pct(t['ok'], ran(t)):>4s} ok"
+                + (f"  ({t['declined']} declined)" if t.get("declined") else ""))
+        lines.append(f"\n  {report['events']} events · {report['turns']} turns")
+        lines.append(f"  {report['path']}")
+
+    return "\n".join(lines)
+
+
+def _in_words(ok: int, calls: int) -> str:
+    """"fails 4 of every 5 calls" beats "20% ok" for the line you read first."""
+    bad = calls - ok
+    if bad == calls:
+        return "fails every time"
+    ratio = calls / bad if bad else 0
+    if ratio >= 1.8:
+        return f"fails 1 call in {round(ratio)}"
+    per5 = round(5 * bad / calls)
+    return f"fails {per5} of every 5 calls"

--- a/symbio/app/skill_eval.py
+++ b/symbio/app/skill_eval.py
@@ -138,6 +138,27 @@ def _keywords(text: str) -> list[str]:
     return out
 
 
+_ENUM_RE = re.compile(r"(?:^|\s)\d+[.)]\s*")
+
+
+def _echoes(reply: str, body: str) -> bool:
+    """Is `reply` essentially the steps text repeated back?
+
+    Containment either way, on text normalised for case, whitespace and list
+    enumerators. Deliberately a blunt textual test rather than keyword
+    coverage: this is asked about *training samples*, where a seeded sample's
+    answer is literally the procedure, and the answer must not depend on the
+    keyword extraction that a `## Triggers` section already skews.
+    """
+    def norm(text: str) -> str:
+        return " ".join(_ENUM_RE.sub(" ", text.lower()).split())
+
+    a, b = norm(reply), norm(body)
+    if not a or not b:
+        return False
+    return a in b or b in a
+
+
 def coverage(reply: str, keywords: list[str]) -> float:
     """Fraction of the skill's step vocabulary present in the reply."""
     if not keywords:
@@ -320,6 +341,68 @@ def tasks_path_for(role: str) -> Path:
     return constants.data_dir_for(role) / "eval_tasks.json"
 
 
+def has_custom_tasks(role: str) -> bool:
+    """Does this skill have hand-written eval tasks, rather than derived ones?"""
+    try:
+        return tasks_path_for(role).exists()
+    except Exception:
+        return False
+
+
+def corpus_teaches_recitation(role: str, steps: str) -> bool:
+    """Do this worker's training samples answer by reproducing its steps text?
+
+    Decides whether derived golden cases may *revert* a retrain or only report
+    it, and the honest answer depends on what the corpus is teaching.
+
+    A freshly seeded skill has six samples that all answer with the steps text.
+    There, "recite the steps" IS the target, the derived cases measure the real
+    thing, and a worker that comes back with "I don't know." must be rolled
+    back. Once real demonstrations replace those seeds the target has changed:
+    the worker is meant to perform the skill, so it stops reproducing the steps
+    by design and the derived cases start scoring specialisation as damage.
+    Measured: a worker trained on 20 real demonstrations was rolled back on 4
+    derived checks, then held its learned behaviour across 8 held-out scenarios
+    once the rollback was suppressed.
+
+    Conservative on every failure path: an unreadable or empty corpus returns
+    True, keeping the guard rail on rather than silently removing it.
+
+    Compares text directly rather than reusing the derived cases' keyword
+    coverage. That path takes its keywords from the whole note, so for a skill
+    with a `## Triggers` section it scores replies against trigger vocabulary
+    ("broken", "cannot", "keywords") instead of the procedure: fix_wifi's own
+    correct answer scores 0.15 against itself. Whatever that is worth as a
+    golden check, it cannot be trusted to answer this question.
+    """
+    body = _step_body(steps).strip() if steps else ""
+    if not body:
+        return True
+    path = constants.data_dir_for(role) / "train.jsonl"
+    try:
+        lines = [l for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    except OSError:
+        return True
+    if not lines:
+        return True
+    reciting = total = 0
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        answers = [m.get("content", "") for m in (row.get("messages") or [])
+                   if m.get("role") == "assistant"]
+        if not answers:
+            continue
+        total += 1
+        if _echoes(answers[-1], body):
+            reciting += 1
+    if not total:
+        return True
+    return reciting * 2 >= total
+
+
 def load_tasks(role: str, name: str) -> tuple[list[SkillTask], bool]:
     """Hand-written tasks for a skill if present, else generated ones.
 
@@ -470,8 +553,21 @@ def resolve_skill(role_or_name: str) -> dict[str, Any] | None:
     return None
 
 
+_SECTION_RE = re.compile(r"^#{2,}\s", re.MULTILINE)
+
+
 def skill_steps(entry: dict[str, Any]) -> str:
-    """Recover a skill's steps from its note, falling back to its prompt."""
+    """Recover a skill's steps from its note, falling back to its prompt.
+
+    Only the procedure, not the whole note. A skill note carries a `## Triggers`
+    section listing routing keywords and example phrasings, and every caller of
+    this uses the result as the answer key for grading. Including that section
+    graded replies against trigger vocabulary instead of the procedure:
+    fix_wifi's own correct answer, "1. Toggle wifi off. 2. Toggle it on.",
+    scored 0.15 coverage against a 0.5 floor — the right answer failed its own
+    check, which quietly disabled the worker regression gate for every skill
+    with triggers.
+    """
     from symbio.app import skills
 
     name = entry.get("skill_name", "")
@@ -482,6 +578,11 @@ def skill_steps(entry: dict[str, Any]) -> str:
             except OSError:
                 break
             body = text.split("\n", 1)[1] if "\n" in text else ""
+            # Cut at the first sub-heading: everything above it is the
+            # procedure, everything below is metadata about when to route here.
+            section = _SECTION_RE.search(body)
+            if section:
+                body = body[:section.start()]
             if body.strip():
                 return body.strip()
     # Fall back to the Steps block embedded in the stored system prompt.

--- a/symbio/app/tool_eval.py
+++ b/symbio/app/tool_eval.py
@@ -1,0 +1,468 @@
+"""Does the model actually reach its tools? A simulated-instance harness.
+
+golden.py answers "did the reply look right" in a single tool-free turn. It
+deliberately never executes a tool, which is what makes it safe to run around
+every LoRA update — but it also means nothing here has ever measured the thing
+that keeps breaking: whether an invocation the model writes is one the parser
+can actually resolve, and whether the model can finish the job once a result
+comes back.
+
+That gap is not theoretical. The whole cron group was unreachable in practice
+while being correctly declared, correctly grouped and correctly implemented,
+because the model wrote a call shape nothing recognised and a success-looking
+sentence went to the user. Nothing failed. Nothing was logged. It just quietly
+did not happen.
+
+This runs each case as a two-turn conversation and never executes anything:
+
+    system + user(prompt)
+      -> model reply            (turn 1: did a resolvable call come out?)
+      -> [System observation: canned result]   <- simulated, not executed
+      -> model reply            (turn 2: did it finish the job?)
+
+The observation is fed back exactly as chat.py feeds a real one — a user turn
+whose content starts with "[System observation: " — so a pass here means the
+same shape of exchange would have worked live.
+
+Results are a four-stage funnel rather than a pass/fail, because where it
+breaks is the whole diagnostic value:
+
+    invoked      the reply contained a call the parser could resolve at all
+    right_tool   ...and it was the tool the case asked for
+    right_args   ...and the arguments were usable
+    completed    ...and after the result came back, the final answer was right
+
+A model that scores 0% on `invoked` needs prompt examples or constrained
+decoding. One that invokes fine but fails `completed` needs different training
+entirely. A single number could not tell those apart.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple
+
+from . import prompts, tooling
+
+OBSERVATION_PREFIX = "[System observation: "
+
+STAGES = ("invoked", "right_tool", "right_args", "completed")
+
+
+class ToolCase(NamedTuple):
+    id: str
+    description: str
+    prompt: str
+    expect_tool: str
+    # What the simulated tool "returns". Kept literal and boring on purpose:
+    # a case should fail because the model could not use a normal result, not
+    # because the fixture was exotic.
+    observation: str
+    # Other tools that solve the case just as well. Without this the harness
+    # scores a reasonable choice as a failure and sends you to fix a model that
+    # was right: "look up X on the web" is served by web_search or by
+    # read_page, and only one of them can be expect_tool.
+    also_accept: tuple[str, ...] = ()
+    check_args: Callable[[dict[str, Any]], bool] | None = None
+    check_final: Callable[[str], bool] | None = None
+
+    @property
+    def accepted(self) -> tuple[str, ...]:
+        return (self.expect_tool,) + tuple(self.also_accept)
+
+
+class CaseResult(NamedTuple):
+    id: str
+    reached: str            # furthest stage reached, or "" if nothing worked
+    called: str | None      # the tool actually invoked, if any
+    args: dict[str, Any]
+    turn1: str
+    turn2: str
+    note: str = ""
+
+    @property
+    def passed(self) -> bool:
+        return self.reached == STAGES[-1]
+
+
+def _contains(*needles: str) -> Callable[[str], bool]:
+    """Final-answer check: the reply mentions each needle, case-insensitively.
+
+    Deliberately loose. This harness measures whether the tool round-trip
+    works, not whether the prose is elegant — a strict match would fail good
+    answers and make the funnel lie about where the problem is.
+    """
+    def check(display: str) -> bool:
+        low = display.lower()
+        return bool(display.strip()) and all(n.lower() in low for n in needles)
+    return check
+
+
+def _any_of(*alternatives: str) -> Callable[[str], bool]:
+    """Final-answer check: any one of these phrasings will do.
+
+    Needed because a strict grader manufactures failures. Measured: the model
+    was handed "All subsystems healthy. 0 errors." and answered "System check
+    passed." — a correct use of the result, scored as a miss because the check
+    demanded the literal word "health". Two of the three system_check
+    "failures" in a full run were this, not the model.
+    """
+    def check(display: str) -> bool:
+        low = display.lower()
+        return bool(display.strip()) and any(a.lower() in low for a in alternatives)
+    return check
+
+
+def _args_have(*keys: str) -> Callable[[dict[str, Any]], bool]:
+    def check(args: dict[str, Any]) -> bool:
+        return all(str(args.get(k, "")).strip() for k in keys)
+    return check
+
+
+# The default battery leads with the tools that actually failed in the wild.
+DEFAULT_CASES: tuple[ToolCase, ...] = (
+    ToolCase(
+        id="cron_schedule",
+        description="A daily reminder reaches schedule_job",
+        prompt="Remind me to stretch every day at 9am.",
+        expect_tool="schedule_job",
+        observation="Scheduled job 12: 'stretch' at 0 9 * * *.",
+        check_args=_args_have("schedule"),
+        check_final=_contains("stretch"),
+    ),
+    ToolCase(
+        id="cron_list",
+        description="Asking what is scheduled reaches list_cron_jobs",
+        prompt="What reminders do I have set up?",
+        expect_tool="list_cron_jobs",
+        observation="1 job: id 12, 'stretch', 0 9 * * *.",
+        check_final=_contains("stretch"),
+    ),
+    ToolCase(
+        # The control in a natural experiment the prompt sets up for free.
+        # delete_cron_job is the ONLY cron tool with a worked <tool_call>
+        # example in prompt.md (line 87). schedule_job and list_cron_jobs are
+        # named in prose there and never demonstrated, and both fail. If the
+        # declared-but-never-demonstrated theory is right, this one passes
+        # while its two siblings do not — same tool group, same machinery, same
+        # turn shape, differing only in whether the model has seen it called.
+        id="cron_delete",
+        description="Deleting a reminder reaches delete_cron_job (has an example)",
+        prompt="Delete the reminder with id 1.",
+        expect_tool="delete_cron_job",
+        observation="Deleted job 1.",
+        check_final=_contains("delet"),
+    ),
+    ToolCase(
+        id="shell_command",
+        description="A shell request reaches run_command",
+        prompt="Run `uname -s` and tell me what it prints.",
+        expect_tool="run_command",
+        observation="Darwin",
+        check_args=_args_have("cmd"),
+        check_final=_contains("darwin"),
+    ),
+    ToolCase(
+        id="web_search",
+        description="A lookup reaches web_search",
+        prompt="Search the web for the current Mars rover mission name.",
+        expect_tool="web_search",
+        observation="Top result: NASA's Perseverance rover is active on Mars.",
+        # Fetching a page is a legitimate way to answer a lookup; scoring it as
+        # a miss measures the case's phrasing, not the model.
+        also_accept=("read_page",),
+        check_args=_args_have("query"),
+        check_final=_contains("perseverance"),
+    ),
+    ToolCase(
+        id="read_file",
+        description="A file read reaches read_file",
+        prompt="Read the file notes/todo.md and summarise it.",
+        expect_tool="read_file",
+        observation="- buy milk\n- call the dentist",
+        check_final=_contains("dentist"),
+    ),
+    ToolCase(
+        id="system_check",
+        description="A health question reaches system_check",
+        prompt="Run a health check on yourself and report the result.",
+        expect_tool="system_check",
+        observation="All subsystems healthy. 0 errors.",
+        check_final=_any_of("health", "passed", "no errors", "0 errors", "fine", "ok"),
+    ),
+)
+
+
+
+
+# --------------------------------------------------------------------------
+# The full surface.
+#
+# DEFAULT_CASES covers the tools that were already known broken. This covers
+# everything else the parser can resolve, so "which tools can the model
+# actually reach" has an answer for all of them rather than for seven.
+#
+# Every observation is a plausible, boring result. A case should fail because
+# the model could not reach the tool or could not use what came back — never
+# because the fixture was strange.
+
+EXTENDED_CASES: tuple[ToolCase, ...] = DEFAULT_CASES + (
+    ToolCase(
+        id="cron_update", description="Changing a job reaches update_cron_job",
+        prompt="Change reminder 3 to run at 10am instead.",
+        expect_tool="update_cron_job", observation="Job 3 now runs at 0 10 * * *.",
+        check_final=_any_of("10", "updated", "changed"),
+    ),
+    ToolCase(
+        id="execute_code", description="A calculation reaches execute_code",
+        prompt="Use Python to work out 2 to the power of 20.",
+        expect_tool="execute_code", observation="1048576",
+        also_accept=("run_command",), check_final=_contains("1048576"),
+    ),
+    ToolCase(
+        id="read_page", description="Reading a URL reaches read_page",
+        prompt="Read https://example.com and tell me the heading.",
+        expect_tool="read_page", observation="Example Domain. This domain is for use in illustrative examples.",
+        also_accept=("browser_open",), check_final=_contains("example domain"),
+    ),
+    ToolCase(
+        id="browser_open", description="Opening a site reaches browser_open",
+        prompt="Open apple.com in the browser.",
+        expect_tool="browser_open", observation="Opened https://apple.com",
+        check_final=_any_of("open", "apple"),
+    ),
+    ToolCase(
+        id="write_note", description="Saving a note reaches write_note",
+        prompt="Save a note titled Groceries saying: milk and eggs.",
+        expect_tool="write_note", observation="Saved note 'Groceries'.",
+        check_final=_any_of("saved", "note", "groceries"),
+    ),
+    ToolCase(
+        id="save_memory", description="A durable fact reaches save_memory",
+        prompt="Remember permanently that my dentist is Dr Chen.",
+        expect_tool="save_memory", observation="Saved to memory.",
+        also_accept=("write_note",), check_final=_any_of("remember", "saved", "chen"),
+    ),
+    ToolCase(
+        id="write_file", description="Writing a file reaches write_file",
+        prompt="Write the text hello world to /tmp/greeting.txt.",
+        expect_tool="write_file", observation="Wrote 11 bytes to /tmp/greeting.txt.",
+        also_accept=("run_command", "edit_file"), check_final=_any_of("wrote", "written", "greeting"),
+    ),
+    ToolCase(
+        id="config_show", description="Asking about settings reaches config_show",
+        prompt="Show me my current configuration settings.",
+        expect_tool="config_show", observation="model_name=Qwen/Qwen3-8B-MLX-4bit, temperature=0.6",
+        check_final=_any_of("qwen", "temperature", "config"),
+    ),
+    ToolCase(
+        id="digest_notes", description="Asking to digest reaches digest_notes",
+        prompt="Digest my notes into the training data.",
+        expect_tool="digest_notes", observation="Digested 47 notes.",
+        check_final=_any_of("47", "digest"),
+    ),
+    ToolCase(
+        id="verify_features", description="Asking to verify reaches verify_features",
+        prompt="Verify that all my enabled features actually work.",
+        expect_tool="verify_features", observation="12 features checked, all healthy.",
+        also_accept=("system_check",), check_final=_any_of("12", "health", "feature"),
+    ),
+    ToolCase(
+        id="delegate_mock_aws",
+        description="An AWS question reaches the mock_aws_client worker",
+        prompt="Use the mock_aws_client worker to list my S3 buckets.",
+        expect_tool="delegate_task",
+        observation="Worker mock_aws_client replied: buckets are backups, logs, assets.",
+        check_final=_any_of("backups", "logs", "assets", "bucket"),
+    ),
+    ToolCase(
+        id="delegate_research",
+        description="A research request reaches the research_brief worker",
+        prompt="Delegate to the research_brief worker: summarise the state of solid-state batteries.",
+        expect_tool="delegate_task",
+        observation="Worker research_brief replied: solid-state cells promise higher density but scaling is unsolved.",
+        check_final=_any_of("solid-state", "density", "scaling"),
+    ),
+    ToolCase(
+        id="compact_memory", description="A full memory store reaches compact_memory",
+        prompt="My memory store is too big. Compact it.",
+        expect_tool="compact_memory", observation="Memory compacted from 40 KB to 12 KB.",
+        check_final=_any_of("compact", "12"),
+    ),
+    ToolCase(
+        id="run_remote", description="A remote command reaches run_remote",
+        prompt="Run uptime on the host called myserver over SSH.",
+        expect_tool="run_remote", observation="up 14 days, load average 0.2",
+        also_accept=("run_command",), check_final=_any_of("14 days", "uptime", "load"),
+    ),
+    ToolCase(
+        id="browser_close", description="Closing the browser reaches browser_close",
+        prompt="Close the browser please.",
+        expect_tool="browser_close", observation="Browser closed.",
+        check_final=_any_of("closed", "done"),
+    ),
+    ToolCase(
+        id="add_golden_case", description="Adding a regression case reaches add_golden_case",
+        prompt="Add a golden test case so you never again forget my name.",
+        expect_tool="add_golden_case", observation="Added golden case 'remembers_name'.",
+        check_final=_any_of("added", "golden", "case"),
+    ),
+)
+
+
+def run_tool_cases(
+    model,
+    tokenizer,
+    system_prompt: str,
+    config: dict[str, Any],
+    generate_fn,
+    sampler=None,
+    cases: tuple[ToolCase, ...] | None = None,
+    max_tokens: int = 200,
+    enabled_groups: set[str] | None = None,
+    enable_thinking: bool = False,
+    repeats: int = 1,
+    output_fn=print,
+) -> dict[str, Any]:
+    """Run every case as a simulated two-turn exchange. Executes nothing.
+
+    `repeats` runs each case that many times and reports the rate, because a
+    single pass at serving temperature is dice. Measured on this model, one
+    greedy run and one served run gave the same completed count with DIFFERENT
+    cases failing: cron_list passed at 0.6 and failed at 0.0, system_check the
+    other way round. Only a case that fails repeatedly is telling you
+    something. golden.py carries the same warning from the same lesson.
+    """
+    cases = cases if cases is not None else DEFAULT_CASES
+    context = system_prompt + prompts.env_note() + prompts.time_note()
+    results: list[CaseResult] = []
+
+    if repeats > 1:
+        cases = tuple(c for c in cases for _ in range(repeats))
+
+    for i, case in enumerate(cases, 1):
+        output_fn(f"  [ToolEval] {i}/{len(cases)} {case.id}...")
+        messages = [{"role": "system", "content": context},
+                    {"role": "user", "content": case.prompt}]
+        turn1 = _generate(model, tokenizer, messages, generate_fn, sampler,
+                          max_tokens, enable_thinking)
+        if turn1 is None:
+            results.append(CaseResult(case.id, "", None, {}, "", "",
+                                      "generation error"))
+            continue
+
+        tools = tooling.parse_tools(turn1, enabled_groups)
+        if not tools:
+            # The failure that started all this: a reply that reads like
+            # success and invokes nothing.
+            results.append(CaseResult(case.id, "", None, {}, turn1, "",
+                                      "no resolvable tool call"))
+            continue
+
+        # Take the accepted tool if the reply contains one anywhere, not
+        # blindly tools[0]. A reply that calls the right tool second was being
+        # graded as a wrong-tool failure.
+        match = next((t for t in tools if t[0] in case.accepted), None)
+        called, args = match if match is not None else tools[0]
+
+        reached = "invoked"
+        if match is None:
+            # Name what it DID call. Reporting only "expected list_cron_jobs"
+            # says a case failed without saying how to fix it — and for a
+            # wrong-tool failure the tool it chose instead is the entire
+            # diagnosis.
+            offered = ", ".join(sorted({t[0] for t in tools}))
+            results.append(CaseResult(
+                case.id, reached, called, args, turn1, "",
+                f"called {offered} instead of {case.expect_tool}"))
+            continue
+
+        reached = "right_tool"
+        if case.check_args is not None and not case.check_args(args):
+            results.append(CaseResult(case.id, reached, called, args, turn1, "",
+                                      "arguments unusable"))
+            continue
+
+        reached = "right_args"
+        # Feed the result back the way chat.py does — as a user turn.
+        messages += [
+            {"role": "assistant", "content": turn1},
+            {"role": "user",
+             "content": f"{OBSERVATION_PREFIX}{case.observation}]"},
+        ]
+        turn2 = _generate(model, tokenizer, messages, generate_fn, sampler,
+                          max_tokens, enable_thinking)
+        if turn2 is None:
+            results.append(CaseResult(case.id, reached, called, args, turn1, "",
+                                      "generation error on turn 2"))
+            continue
+
+        display = tooling.strip_tool_tags(turn2)
+        ok = case.check_final is None or case.check_final(display)
+        results.append(CaseResult(
+            case.id, "completed" if ok else reached, called, args, turn1,
+            display, "" if ok else "final answer did not use the result"))
+
+    return _summarise(results, output_fn)
+
+
+def _generate(model, tokenizer, messages, generate_fn, sampler, max_tokens,
+              enable_thinking) -> str | None:
+    chat_prompt = tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True,
+        enable_thinking=enable_thinking)
+    try:
+        return generate_fn(model, tokenizer, prompt=chat_prompt,
+                           sampler=sampler, max_tokens=max_tokens,
+                           verbose=False).strip()
+    except Exception:
+        return None
+
+
+def _summarise(results: list[CaseResult], output_fn) -> dict[str, Any]:
+    total = len(results) or 1
+    funnel = {}
+    for idx, stage in enumerate(STAGES):
+        reached = sum(1 for r in results
+                      if r.reached and STAGES.index(r.reached) >= idx)
+        funnel[stage] = reached
+
+    output_fn("\n  [ToolEval] funnel over "
+              f"{len(results)} case(s):")
+    for stage in STAGES:
+        n = funnel[stage]
+        output_fn(f"    {stage:11s} {n}/{len(results)}  ({100 * n / total:.0f}%)")
+
+    # Per case, so a flaky one reads as flaky instead of as two separate
+    # failures. A case that passes sometimes is a different problem from one
+    # that never passes, and only the second is worth changing the prompt for.
+    per_case: dict[str, dict[str, Any]] = {}
+    for r in results:
+        slot = per_case.setdefault(
+            r.id, {"runs": 0, "passed": 0, "notes": [], "sample": ""})
+        slot["runs"] += 1
+        slot["passed"] += int(r.passed)
+        if not r.passed:
+            slot["notes"].append(r.note or r.reached or "nothing")
+            if not slot["sample"]:
+                slot["sample"] = " ".join((r.turn1 or "").split())[:160]
+
+    imperfect = {k: v for k, v in per_case.items() if v["passed"] < v["runs"]}
+    if imperfect:
+        output_fn("\n  [ToolEval] where it stopped:")
+        for cid, v in imperfect.items():
+            verdict = "never" if v["passed"] == 0 else "flaky"
+            note = v["notes"][0] if v["notes"] else ""
+            output_fn(f"    {cid:16s} {v['passed']}/{v['runs']} "
+                      f"{verdict:6s} {note}")
+            # The reply itself, right here. Needing a second script to see what
+            # the model actually said is how a wrong-tool failure stayed
+            # undiagnosed through a full 18-run pass.
+            if v["sample"]:
+                output_fn(f"                     said: {v['sample']}")
+
+    return {
+        "total": len(results),
+        "passed": sum(1 for r in results if r.passed),
+        "funnel": funnel,
+        "per_case": per_case,
+        "results": [r._asdict() for r in results],
+    }

--- a/symbio/app/tooling.py
+++ b/symbio/app/tooling.py
@@ -792,6 +792,160 @@ def _extract_bare_tool_calls(text: str) -> list[tuple[int, int, dict[str, Any]]]
     return out
 
 
+# Canonical tool names only, longest first so `list_cron_jobs` wins over a
+# shorter name that prefixes it.
+#
+# Deliberately NOT including _HERMES_NAME_MAP's short aliases. Those contain
+# bare words like "type", "read" and "open", and the dedicated XML handlers
+# above already parse <type enter="true">...</type> — matching it here too
+# would emit the same call twice. write_note is excluded for the same reason:
+# the self-closing <note/>|<write_note/> handler already covers it.
+_CALLABLE_NAMES = sorted(
+    (n for n in _TOOL_GROUPS if n != "write_note"), key=len, reverse=True)
+_NAME_ALT = "|".join(re.escape(n) for n in _CALLABLE_NAMES)
+
+# Improvised function-call syntax, with arguments.
+#
+# 25 of the 27 tools declared in the <tools> block have no worked example
+# anywhere in the assembled system prompt — only compact_memory and config_set
+# do. A tool the model has seen declared but never seen *called* gets a call
+# shape invented for it, and the invented shape is consistently a dotted or
+# parenthesised function with keyword attributes:
+#
+#     .schedule_job schedule="0 9 * * *" text="stretch"
+#     schedule_job(schedule="0 9 * * *", text="stretch")
+#     <schedule_job schedule="0 9 * * *" text="stretch" />
+#
+# None of these matched any pattern, so the tool silently never ran and the
+# raw text was printed to the user as the reply — a success-looking line for
+# a job that was never created. That is the same failure the self-closing
+# <note/> handler above was written for; this generalises it to every tool
+# instead of fixing them one at a time as each is caught in the wild.
+#
+# Anchored on the exact declared names, so prose cannot trip it.
+_FUNC_ATTR_RE = re.compile(
+    r'[.<]?\b(' + _NAME_ALT + r')\b\s*\(?\s*'
+    r'((?:\w+\s*=\s*(?:"[^"]*"|\'[^\']*\')\s*,?\s*)+)\)?\s*/?>?'
+)
+
+# The same, with no arguments: `.list_cron_jobs` or `list_cron_jobs()`. The
+# dot or the parentheses are required — a bare tool name is far too common in
+# ordinary prose ("I'll delegate_task to the worker") to treat as a call.
+_FUNC_NOARG_RE = re.compile(
+    r'(?:\.(' + _NAME_ALT + r')\b(?!\s*\()|\b(' + _NAME_ALT + r')\s*\(\s*\))'
+)
+
+_ATTR_PAIR_RE = re.compile(r'(\w+)\s*=\s*(["\'])(.*?)\2', re.DOTALL)
+
+
+def _in_code_fence(text: str, index: int) -> bool:
+    """True when `index` falls inside a markdown code fence — the model is
+    showing an example there, not calling anything."""
+    return text[:index].count("```") % 2 == 1
+
+
+def _find_function_attr_calls(
+        reply: str) -> list[tuple[int, int, str, dict[str, Any]]]:
+    """Recognise the improvised function form for any declared tool.
+
+    Returns (start, end, name, params) so callers can both execute the call and
+    cut it out of the visible reply — a recovered call that still printed its
+    raw tag to the user would be a worse bug than not recovering it.
+
+    Regions already wrapped in the XML tool-call tag are masked out so a
+    well-formed call is not also counted here.
+    """
+    masked = list(reply)
+    for m in _WRAPPED_TOOL_CALL_RE.finditer(reply):
+        for i in range(m.start(), m.end()):
+            masked[i] = "\x00"
+    scan = "".join(masked)
+
+    out: list[tuple[int, int, str, dict[str, Any]]] = []
+    seen: set[tuple[int, int]] = set()
+
+    for m in _FUNC_ATTR_RE.finditer(scan):
+        if _in_code_fence(reply, m.start()):
+            continue
+        name = _HERMES_NAME_MAP.get(m.group(1), m.group(1))
+        if name not in _TOOL_GROUPS:
+            continue
+        params = {k.lower(): v for k, _q, v in _ATTR_PAIR_RE.findall(m.group(2))}
+        if not params:
+            continue
+        seen.add((m.start(), m.end()))
+        out.append((m.start(), m.end(), name, _normalize_args(name, params)))
+
+    for m in _FUNC_NOARG_RE.finditer(scan):
+        if _in_code_fence(reply, m.start()):
+            continue
+        if any(s <= m.start() < e for s, e in seen):
+            continue
+        raw = m.group(1) or m.group(2)
+        name = _HERMES_NAME_MAP.get(raw, raw)
+        if name not in _TOOL_GROUPS:
+            continue
+        out.append((m.start(), m.end(), name, {}))
+
+    return out
+
+
+def _extract_function_attr_calls(reply: str) -> list[tuple[str, dict[str, Any]]]:
+    return [(n, p) for _s, _e, n, p in _find_function_attr_calls(reply)]
+
+
+# One key, its value running to the delimiter that ends it: either a comma
+# before the next "key": , or the closing brace of the arguments object.
+_LOOSE_FIELD_RE = re.compile(
+    r'"(?P<key>\w+)"\s*:\s*"(?P<val>.*?)"\s*(?=,\s*"\w+"\s*:|\s*\}\s*\}?\s*$)',
+    re.DOTALL)
+
+
+def _repair_tool_call_json(raw: str) -> dict[str, Any] | None:
+    """Recover a tool call whose JSON the model failed to escape.
+
+    Writing code through a JSON string is the one thing this model reliably
+    gets wrong. Asked to insert a database row it produced:
+
+        {"name": "execute_code", "arguments": {"code": "import sqlite3
+        ...cur.execute("INSERT INTO users ...")"}}
+
+    — a raw newline and an unescaped double quote inside a JSON string. The
+    object does not parse, so the call vanished completely and the turn did
+    nothing, silently. Any code containing a quote hits this, which is most
+    code worth running.
+
+    Rather than guess at arbitrary broken JSON, this pulls out the name and
+    then each "key": "value" pair by scanning to the delimiter that ends it,
+    taking the value verbatim. Returns None when the shape is not recognisable
+    — a wrong repair would be worse than no call.
+    """
+    name_m = re.search(r'"(?:name|function)"\s*:\s*"([^"]+)"', raw)
+    if not name_m:
+        return None
+
+    args_m = re.search(r'"(?:arguments|parameters|args)"\s*:\s*\{(.*)\}',
+                       raw, re.DOTALL)
+    params: dict[str, Any] = {}
+    if args_m:
+        body = args_m.group(1)
+        for f in _LOOSE_FIELD_RE.finditer(body):
+            value = f.group("val")
+            # The model escaped some of it correctly; honour what it did.
+            value = (value.replace("\\n", "\n").replace("\\t", "\t")
+                          .replace('\\"', '"').replace("\\\\", "\\"))
+            params[f.group("key")] = value
+        # Numbers and booleans, which need no quote handling.
+        for f in re.finditer(r'"(\w+)"\s*:\s*(-?\d+(?:\.\d+)?|true|false)\b', body):
+            key, lit = f.group(1), f.group(2)
+            if key in params:
+                continue
+            params[key] = (True if lit == "true" else False if lit == "false"
+                           else float(lit) if "." in lit else int(lit))
+
+    return {"name": name_m.group(1), "arguments": params}
+
+
 def parse_tools(reply: str, enabled_groups: set[str] | None = None) -> list[tuple[str, dict[str, Any]]]:
     """Extract tool calls from the model reply.
 
@@ -970,7 +1124,9 @@ def parse_tools(reply: str, enabled_groups: set[str] | None = None) -> list[tupl
         try:
             call = json.loads(m.group(1).strip())
         except json.JSONDecodeError:
-            continue
+            call = _repair_tool_call_json(m.group(1).strip())
+            if call is None:
+                continue
         if not isinstance(call, dict):
             continue
         name = call.get("name") or call.get("function")
@@ -991,6 +1147,12 @@ def parse_tools(reply: str, enabled_groups: set[str] | None = None) -> list[tupl
         if isinstance(name, str):
             internal_name = _HERMES_NAME_MAP.get(name, name)
             tools.append((internal_name, _normalize_args(internal_name, params)))
+
+    # Improvised function form, for the tools the prompt declares but never
+    # demonstrates. Last, so a well-formed call in any supported syntax is
+    # already in `tools` and this only ever adds what nothing else caught.
+    if not tools:
+        tools.extend(_extract_function_attr_calls(reply))
 
     if enabled_groups is not None:
         tools = [
@@ -1123,6 +1285,15 @@ def strip_tool_tags(reply: str) -> str:
     # Drop bare JSON tool-call objects the model may emit unwrapped, so the
     # raw JSON never reaches the visible reply.
     for _start, _end, _c in sorted(_extract_bare_tool_calls(display), key=lambda s: s[0], reverse=True):
+        display = display[:_start] + display[_end:]
+    # And the improvised function forms parse_tools now executes. Recovering
+    # the call but still printing its raw tag is worse than not recovering it:
+    # observed live as
+    #     Caine: >tag
+    #     <schedule_job schedule="0 9 * * *" text="stretch"/>
+    # where the job WAS created and the user was shown the markup anyway.
+    for _start, _end, _n, _p in sorted(
+            _find_function_attr_calls(display), key=lambda s: s[0], reverse=True):
         display = display[:_start] + display[_end:]
     display = _UNTERMINATED_TAG_RE.sub('', display)
     return clean_response(display)

--- a/symbio/app/training.py
+++ b/symbio/app/training.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
@@ -83,6 +84,77 @@ def free_ram_bytes() -> int | None:
         return None
     reclaimable = sum(pages.get(k, 0) for k in ("free", "inactive", "speculative"))
     return reclaimable * page_size
+
+# Set by run_training when the trainer child has exited, cleared by the settle
+# that waits it out. It is what makes settle_after_trainer_exit a no-op for a
+# caller whose run_training was stubbed — there was no child, so there is no
+# bulk teardown to wait for, and sleeping would be pure cost.
+_trainer_child_exited = False
+
+
+def settle_after_trainer_exit(config: dict[str, Any] | None = None,
+                              status_fn=None) -> None:
+    """Wait for a dead trainer's GPU memory to actually come back.
+
+    Process exit is the reliable way to reclaim MLX weights, but it hands every
+    Metal buffer back to the kernel in one bulk teardown. Loading the next
+    model into the middle of that teardown is what took this machine down three
+    times on 2026-08-17:
+
+        panic: "pending memory object unexpectedly found in non pending hash"
+        @IOGPUGroupMemory.cpp:528
+
+    IOGPUFamily tracks GPU memory objects in a pending/non-pending hash pair. A
+    bulk unmap, plus a concurrent wired-collector pass, plus a fresh multi-GB
+    allocation, is enough to have an object reclassified mid-flight, and the
+    driver panics rather than continue on inconsistent page-table state.
+
+    The fixed floor is not redundant with the poll. vm_stat reports pages as
+    free the moment the process dies, but the driver's own reclaim runs behind
+    that — memory can read as available while IOGPUFamily is still walking its
+    hashes. The floor covers the part that cannot be observed from userspace;
+    the poll covers the part that can.
+
+    This belongs only where a child process has exited. In-process frees go
+    through the live allocator with no mass unmap event, and paying a
+    multi-second floor for one would be latency spent on a race that shape
+    cannot produce — which is why the interactive delegation path does not
+    call this.
+
+    Never raises. A machine that will not drain is a reason to say so and carry
+    on, not to lose a training run that already succeeded.
+    """
+    global _trainer_child_exited
+    if not _trainer_child_exited:
+        return
+    _trainer_child_exited = False
+
+    lora_cfg = (config or {}).get("lora", {})
+    floor = float(lora_cfg.get("settle_after_training_seconds", 15))
+    need_gb = float(lora_cfg.get("settle_free_gb", 6.0))
+    timeout = float(lora_cfg.get("settle_timeout_seconds", 180))
+    if floor <= 0:
+        return
+    time.sleep(floor)
+    need = int(need_gb * 1024 ** 3)
+    deadline = time.monotonic() + timeout
+    while True:
+        free = free_ram_bytes()
+        if free is None:
+            return  # Cannot measure; the floor wait is all there is.
+        if free >= need:
+            return
+        # Clamped to the deadline so `timeout` means what it says rather than
+        # overshooting by up to a full poll interval.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(5.0, remaining))
+    free = free_ram_bytes()
+    have = f"{free / 1024 ** 3:.1f} GB" if free is not None else "unknown"
+    message = (f"  [Train] Memory did not drain to {need_gb:.0f} GB within "
+               f"{timeout:.0f}s (free: {have}); continuing anyway.")
+    (status_fn or print)(message)
 
 def _train_file_for(role: str | None) -> Path:
     # role=None reads constants.TRAIN_FILE directly (not re-derived from
@@ -1454,17 +1526,31 @@ def iters_for_corpus(lora: dict[str, Any], sample_count: int) -> int:
     `lora.iters` is kept as a floor rather than dropped, so a small corpus
     still gets enough steps to converge, and `lora.max_iters` caps the top end
     so a large one cannot run away.
+
+    The floor is itself bounded by `lora.max_epochs`, because on a small corpus
+    it stops being a floor and becomes the whole schedule. A 6-sample skill
+    corpus needs 12 steps at 2 epochs; the 150 floor turned that into 25 epochs,
+    which is not "enough steps to converge" but memorisation of six strings —
+    and it is why every skill worker recited its seed samples instead of
+    generalising. Measured: at 3 epochs over 20 samples the same recipe held
+    learned constraints across held-out scenarios; at 25 epochs it did not.
     """
     epochs = float(lora.get("epochs", 2))
+    max_epochs = float(lora.get("max_epochs", 4))
     batch_size = max(1, int(lora.get("batch_size", 1)))
     floor = int(lora.get("iters", 150))
     cap = int(lora.get("max_iters", 2000))
     if sample_count <= 0 or epochs <= 0:
         return min(cap, floor)
     needed = math.ceil(epochs * sample_count / batch_size)
+    # How many steps `max_epochs` passes would take. The floor may not exceed
+    # this, so "give a small corpus a few more steps" cannot silently become
+    # "run it twenty-five times".
+    epoch_ceiling = math.ceil(max_epochs * sample_count / batch_size)
+    effective_floor = min(floor, epoch_ceiling)
     # The cap is applied last so it is a real ceiling: a floor that could
     # override it would make `max_iters` unable to do the one thing it is for.
-    return min(cap, max(floor, needed))
+    return min(cap, max(effective_floor, needed))
 
 def count_samples(role: str | None = None) -> int:
     path = _train_file_for(role)
@@ -1792,6 +1878,14 @@ def run_training(config: dict[str, Any], iters: int | None = None,
                     os.unlink(config_path)
                 except OSError:
                     pass
+
+        # Both branches above ran the trainer as a child process, and it has
+        # exited by the time either returns — including the failure paths,
+        # which unmap just as much as a success does. This is what arms
+        # settle_after_trainer_exit; without it that wait cannot tell a real
+        # teardown from a caller who never spawned anything.
+        global _trainer_child_exited
+        _trainer_child_exited = True
 
     config_file = adapter_dir / "adapter_config.json"
     weight_files = list(adapter_dir.glob("adapters.*"))

--- a/symbio/app/worker_models.json
+++ b/symbio/app/worker_models.json
@@ -136,5 +136,55 @@
     "system_prompt": "You are the specialist worker for the skill 'Brew loose leaf tea'. Follow the steps below exactly, produce only the requested output, and do not add extra commentary.\n\nSteps:\n1. Boil water. 2. Add a tea spoon of loose leaf tea. 3. Let the water cool for a few seconds. 4. Pour the hot water into the tea. 5. Let the tea steep for a few minutes. 6. Strain the tea. 7. Add a bit of honey or lemon for taste.\n\nReply with the result of applying these steps to the user's request.",
     "is_skill": true,
     "skill_name": "Brew loose leaf tea"
+  },
+  "skill_meal_suggestions": {
+    "model_name": "mlx-community/Qwen3-4B-4bit",
+    "role": "meal_suggestions",
+    "description": "Skill: Meal Suggestions",
+    "adapter_compatible": true,
+    "memory_note": "worker-size RAM at runtime, alongside the headmaster",
+    "system_prompt": "You are the specialist worker for the skill 'Meal Suggestions'. Follow the steps below exactly, produce only the requested output, and do not add extra commentary.\n\nSteps:\nSuggest meal ideas that fit the situation the user describes.\n\nReply with the result of applying these steps to the user's request.",
+    "is_skill": true,
+    "skill_name": "Meal Suggestions"
+  },
+  "skill_mock_aws_client": {
+    "model_name": "mlx-community/Qwen3-4B-4bit",
+    "role": "mock_aws_client",
+    "description": "Skill: Mock AWS Client",
+    "adapter_compatible": true,
+    "memory_note": "worker-size RAM at runtime, alongside the headmaster",
+    "system_prompt": "You are the specialist worker for the skill 'Mock AWS Client'. Follow the steps below exactly, produce only the requested output, and do not add extra commentary.\n\nSteps:\nWrite Python that talks to AWS for the task the user describes.\n\nReply with the result of applying these steps to the user's request.",
+    "is_skill": true,
+    "skill_name": "Mock AWS Client"
+  },
+  "skill_research_brief": {
+    "model_name": "mlx-community/Qwen3-4B-4bit",
+    "role": "research_brief",
+    "description": "Skill: Research Brief",
+    "adapter_compatible": true,
+    "memory_note": "worker-size RAM at runtime, alongside the headmaster",
+    "system_prompt": "You are the specialist worker for the skill 'Research Brief'. Follow the steps below exactly, produce only the requested output, and do not add extra commentary.\n\nSteps:\nAnswer the research question the user asks.\n\nReply with the result of applying these steps to the user's request.",
+    "is_skill": true,
+    "skill_name": "Research Brief"
+  },
+  "skill_scrape_script": {
+    "model_name": "mlx-community/Qwen3-4B-4bit",
+    "role": "scrape_script",
+    "description": "Skill: Scrape Script",
+    "adapter_compatible": true,
+    "memory_note": "worker-size RAM at runtime, alongside the headmaster",
+    "system_prompt": "You are the specialist worker for the skill 'Scrape Script'. Follow the steps below exactly, produce only the requested output, and do not add extra commentary.\n\nSteps:\nWrite Python that collects the data the user describes from a website.\n\nReply with the result of applying these steps to the user's request.",
+    "is_skill": true,
+    "skill_name": "Scrape Script"
+  },
+  "skill_change_watcher": {
+    "model_name": "mlx-community/Qwen3-4B-4bit",
+    "role": "change_watcher",
+    "description": "Skill: Change Watcher",
+    "adapter_compatible": true,
+    "memory_note": "worker-size RAM at runtime, alongside the headmaster",
+    "system_prompt": "You are the specialist worker for the skill 'Change Watcher'. Follow the steps below exactly, produce only the requested output, and do not add extra commentary.\n\nSteps:\nWrite Python that watches a page for changes and reports them.\n\nReply with the result of applying these steps to the user's request.",
+    "is_skill": true,
+    "skill_name": "Change Watcher"
   }
 }

--- a/verify_prefetch.py
+++ b/verify_prefetch.py
@@ -1,0 +1,182 @@
+"""Verify the boot-time KV-cache prefetch against a real model.
+
+The 10 unit tests in test_prompt_cache.py cover this logic with fakes. What
+fakes cannot tell you is whether reading a real multi-hundred-MB safetensors
+cache on a background thread, while mlx_lm.load() is allocating its own
+buffers, actually works on this machine and produces a cache the model
+accepts. That is what this checks.
+
+USAGE — two steps, one model load each.
+
+  1. Produce a cache file by using the app normally, if you have not already:
+         python main.py
+     Say anything, then exit. On a clean exit it writes
+     cache/system_prompt.safetensors.
+
+  2. Run this from the repo root (NOT from a worktree — a worktree reseeds
+     security.md to the permissive default, which changes the system prompt
+     and therefore the cache signature):
+         python verify_prefetch.py
+
+Exit code 0 means the prefetch ran, was consumed, and the cache was accepted.
+Non-zero means it fell back to a normal load, with the reason printed.
+
+Safety: refuses to start while an mlx_lm trainer is alive, and waits out a
+recently-exited one, because a trainer's Metal teardown racing a fresh
+multi-GB allocation is this machine's documented kernel-panic pattern.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from symbio import constants
+from symbio.app import chat, config as config_mod
+
+
+def _trainer_alive() -> str | None:
+    """Return a description of a live mlx_lm trainer, or None."""
+    try:
+        out = subprocess.run(["pgrep", "-fl", "mlx_lm"],
+                             capture_output=True, text=True, timeout=10).stdout
+    except Exception:
+        return None
+    for line in out.splitlines():
+        if "lora" in line or "--train" in line:
+            return line.strip()
+    return None
+
+
+def _guard(settle_seconds: float = 30.0) -> None:
+    alive = _trainer_alive()
+    if alive:
+        sys.exit(f"REFUSING: a trainer is running, loading a model now is the "
+                 f"panic pattern.\n  {alive}\nWait for it to finish, then retry.")
+    print(f"  No trainer running. Settling {settle_seconds:.0f}s in case one "
+          f"just exited...")
+    time.sleep(settle_seconds)
+
+
+class Probe:
+    """The real cache methods, bound onto the attributes they touch.
+
+    Same technique as test_prompt_cache.py's FakeSession, but pointed at the
+    real config, the real cache file, and a real model load.
+    """
+
+    _log_info = chat.ChatSession._log_info
+    _prompt_cache_signature = chat.ChatSession._prompt_cache_signature
+    _load_persisted_prompt_cache = chat.ChatSession._load_persisted_prompt_cache
+    _start_prompt_cache_prefetch = chat.ChatSession._start_prompt_cache_prefetch
+    _take_prefetched_cache = chat.ChatSession._take_prefetched_cache
+
+    def __init__(self, cfg):
+        self.config = cfg
+        self.adapter_loaded = (constants.ADAPTER_DIR / "adapter_config.json").exists()
+        self._prompt_cache = None
+        self._cached_prompt_ids = None
+        self._prefetch_thread = None
+        self._prefetched_cache = None
+        self.logged: list[str] = []
+        self.logger = type("L", (), {"info": lambda s, m: self.logged.append(m)})()
+
+
+def main() -> int:
+    path = constants.PROMPT_CACHE_FILE
+    if not path.exists():
+        return _fail(f"No cache file at {path}\n"
+                     f"  Run `python main.py` once and exit cleanly to write one.")
+
+    size_mb = path.stat().st_size / 1024 ** 2
+    print(f"\nKV prefetch verification")
+    print(f"  cache file : {path} ({size_mb:.0f} MB)")
+
+    cfg = config_mod.load_config()
+    model_name = cfg.get("model_name")
+    print(f"  model      : {model_name}")
+    print(f"  adapter    : {'loaded' if (constants.ADAPTER_DIR / 'adapter_config.json').exists() else 'none'}")
+
+    _guard()
+
+    probe = Probe(cfg)
+
+    # Count reads of the cache file. The whole point of the prefetch is that
+    # the file is read ONCE, on the background thread, and handed to
+    # _load_persisted_prompt_cache — which must not read it a second time.
+    reads: list[float] = []
+    real_loader = chat.load_prompt_cache
+
+    def counting_loader(*a, **kw):
+        reads.append(time.monotonic())
+        return real_loader(*a, **kw)
+
+    chat.load_prompt_cache = counting_loader
+    try:
+        t0 = time.monotonic()
+        probe._start_prompt_cache_prefetch()
+        started = time.monotonic() - t0
+        print(f"\n  prefetch thread started at +{started * 1000:.0f} ms")
+
+        from mlx_lm import load
+        print(f"  loading weights (this is the window the read overlaps)...")
+        model, tokenizer = load(model_name)
+        loaded_at = time.monotonic() - t0
+        print(f"  weights loaded at +{loaded_at:.2f} s")
+
+        if not reads:
+            return _fail("the prefetch thread never read the file")
+        read_at = reads[0] - t0
+        print(f"  cache read began at +{read_at * 1000:.0f} ms "
+              f"({'DURING the load' if read_at < loaded_at else 'AFTER the load'})")
+
+        # Rebuild the exact ids the running app signs with. This must match
+        # _prefill_system_prompt_cache byte for byte — system prompt rendered
+        # with an EMPTY user turn, no generation prompt, thinking off — or the
+        # signature will not match and this reports a failure that isn't one.
+        system_prompt = chat.prompts.build_system_prompt(
+            probe.config["assistant_name"], probe.config["user_name"])
+        templated = tokenizer.apply_chat_template(
+            [{"role": "system", "content": system_prompt},
+             {"role": "user", "content": ""}],
+            tokenize=False, add_generation_prompt=False, enable_thinking=False,
+        )
+        system_ids = tokenizer.encode(templated)
+        print(f"  system prefix    : {len(system_ids)} tokens")
+        accepted = probe._load_persisted_prompt_cache(system_ids)
+
+        print(f"\n  file reads total : {len(reads)}  (1 = prefetch consumed, 2 = re-read)")
+        print(f"  cache accepted   : {accepted}")
+        for line in probe.logged:
+            print(f"    log: {line}")
+
+        if len(reads) != 1:
+            return _fail(f"expected exactly 1 read, saw {len(reads)} — "
+                         f"the prefetch was not consumed")
+        if not accepted:
+            return _fail("signature rejected the cache — it was read but not "
+                         "usable. Expected if the model or adapter changed "
+                         "since the file was written; a bug otherwise.")
+        if read_at >= loaded_at:
+            return _fail("the read did not overlap the load — the prefetch "
+                         "gained nothing")
+
+        n = len(probe._cached_prompt_ids or [])
+        kib = 2 * 36 * 8 * 128 * 2 / 1024
+        print(f"\n  PASS — {n} tokens restored without re-prefilling them.")
+        print(f"  Approx KV held: {n * kib / 1024:.0f} MiB at {kib:.0f} KiB/token.")
+        return 0
+    finally:
+        chat.load_prompt_cache = real_loader
+
+
+def _fail(msg: str) -> int:
+    print(f"\n  FAIL — {msg}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
…nd them

A clean branch off main whose history has never contained a test file. Identical in content to worktree-symbio-kvcache-dispatch, which carries the same work across 27 commits but committed the tests along the way. That branch has the detailed per-change reasoning if you want it; this one is what merges.

FIXES

The prompt cache had never run. Not slowly, not intermittently — never, on any boot, since it was written. The prefill ran on a daemon thread, generate_step calls mx.eval on the cache state, MLX's stream registry is thread-local, and it raised "There is no Stream(cpu, N) in current thread" after zero yields. A bare except swallowed it, so every switch controlling the feature read as enabled while no cache file was ever written and every turn logged "cached 0". Entering the main thread's stream inside the worker does not fix it. It now runs on the calling thread: ~24s on a first boot, once, against ~1s on every boot after, because the whole point of persisting is that later boots load the file. Also reads that file during the model load rather than after.

browser_click failed four calls in five — 567 calls, 453 failures, 450 of them "Browser is not open". _last_browsed_url existed since the first commit for exactly this, described in its own comment as being for auto-recovery, and was assigned in one place and read in none. A page action that finds the browser closed now reopens the last URL and retries once. Both failure shapes are handled; a raised "not open" and a returned one are the same thing.

481 of 542 run_command failures were the model launching Chrome as `chrome`, `chromebrowser` or `chrome-app`. env_note() tells it on every single turn that GUI apps have no CLI name and to use `open -a`. It did it anyway, 481 times, so this is deterministic and belongs in code. It still writes the mistake note, because recovering silently would take the user's working action and destroy the training signal in the same move.

Tool calls vanished whenever the model wrote code containing a double quote — the JSON did not parse and the call was skipped in silence. Now repaired by reading each key/value to its delimiter rather than guessing at arbitrary broken JSON; an unrecognisable blob is still skipped, since a wrong repair is worse than no call.

Tools the model was shown a schema for but never a worked example of got a call shape invented for them, which mostly did not parse. Those shapes are now recognised, and stripped from the visible reply — recovering a call and still printing its tag would be worse than not recovering it.

INSTRUMENTS

tool_eval.py runs each case as a simulated two-turn exchange and executes nothing: the tool result is a canned string fed back exactly as chat.py delivers a real one. Results are a funnel — invoked / right_tool / right_args / completed — because where it stops is the diagnostic. 84% of the tool surface completes end to end.

The telemetry was not broken; nothing had ever read it. log_path() was defined and called from nowhere while activity.txt reached 985 KB and 13,049 events. It now reports what is wrong and nothing else, and no longer counts a user declining an action as the tool failing — that made a working safety gate read as a broken tool.

db_agent_test.py does not stop at "did it emit a plausible command". It gives the model a real sqlite database, runs whatever it writes against a throwaway copy, and checks the answer.

TOOLS

install.sh is one command that ends inside the environment. patch_prompt.py applies a measured cron fix to the gitignored prompt.md. archive_adapters.py collects all 26 adapters into Adapter_skills/ with their data and metadata. adapter_seal.py welds each adapter to its training data with an HKDF pair key, so tampering with either is detectable and a challenge can only be answered by something holding both.