### PR TITLE
release: 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ name = "symbio-cli"
 # `planner` module that the distribution never contained, so `symb --help`
 # raised ModuleNotFoundError on any clean install. Versions cannot be reused on
 # PyPI, so the fix ships as 0.1.1.
-version = "0.1.2"
+version = "0.2.0"
 description = "Personal, autonomous, self-finetuning local MLX agent."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
0.1.2 on PyPI predates all of this by a day and contains none of it. The version in pyproject.toml still read 0.1.2, so a build would have been rejected on upload rather than shipping anything.

Minor rather than patch: chat.py was split into six modules, skill workers gained a second golden battery graded by execution, and seeding now harvests worked examples from work the session actually ran. No public API moved(yay) everything removed from chat.py is imported back and got separated ovi. 

Verified before tagging: twine check passes on both artifacts; the wheel carries no per-user data (no worker_models.json, corpus, notes, sessions, adapters, config or memory.db). I also checked deliberately, since this repo's history had to be rewritten on 2026-08-25 for exactly that; all seven new modules are present; and the wheel installs into a clean interpreter.

Also verified for the first time against real weights: the rollback branch, which is the only destructive path in the new battery and had until now run only under mocks. A worker passing 2/2 was retrained on a corpus with its demonstrations removed, scored 0/2, and was reverted adapter checksum identical before and after, so the previous weights were genuinely restored rather than merely reported as restored. The recall battery scored 3/5 both before and after and saw nothing wrong, which is the clearest case yet for why the second battery exists.

So overall, this new update fixes most of the bugs that kept the model from doing tasks and now with this new iteration I am calling this the first time it can do stuff. Have a exquisite day and keep on harnessing 


